### PR TITLE
Return a Config.Config in MachineInventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ operator:
 
 .PHONY: installer
 installer:
-	CGO_ENABLED=0 go build -ldflags "-extldflags -static -w -s -X 'github.com/rancher/elemental-operator/version.Version=$(TAG)'" -o build/elemental-installer $(ROOT_DIR)/cmd/installer
+	go build -ldflags "-w -s -X 'github.com/rancher/elemental-operator/version.Version=$(TAG)'" -o build/elemental-installer $(ROOT_DIR)/cmd/installer
 
 .PHONY: build-docker
 build-docker:

--- a/pkg/apis/elemental.cattle.io/v1beta1/registration.go
+++ b/pkg/apis/elemental.cattle.io/v1beta1/registration.go
@@ -38,7 +38,7 @@ type MachineRegistrationSpec struct {
 	MachineName                 string            `yaml:"machineName,omitempty" json:"machineName,omitempty"`
 	MachineInventoryLabels      map[string]string `yaml:"machineInventoryLabels,omitempty" json:"machineInventoryLabels,omitempty"`
 	MachineInventoryAnnotations map[string]string `yaml:"machineInventoryAnnotations,omitempty" json:"machineInventoryAnnotations,omitempty"`
-	Install                     *config.Install   `yaml:"install,omitempty" json:"install,omitempty"`
+	Config                      *config.Config    `yaml:"config,omitempty" json:"config,omitempty"`
 }
 
 type MachineRegistrationStatus struct {

--- a/pkg/apis/elemental.cattle.io/v1beta1/zz_generated_deepcopy.go
+++ b/pkg/apis/elemental.cattle.io/v1beta1/zz_generated_deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	config "github.com/rancher/elemental-operator/pkg/config"
 	v1alpha1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	upgradecattleiov1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	genericcondition "github.com/rancher/wrangler/pkg/genericcondition"
@@ -432,9 +433,10 @@ func (in *MachineRegistrationSpec) DeepCopyInto(out *MachineRegistrationSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.Install != nil {
-		in, out := &in.Install, &out.Install
-		*out = (*in).DeepCopy()
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = new(config.Config)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,8 +72,8 @@ type Elemental struct {
 }
 
 type Config struct {
-	Elemental Elemental              `json:"elemental,omitempty"`
-	Data      map[string]interface{} `json:"-"`
+	Elemental Elemental              `yaml:"elemental" json:"elemental,omitempty"`
+	Data      map[string]interface{} `yaml:"data" json:"data"`
 }
 
 type YipConfig struct {
@@ -88,4 +88,17 @@ type User struct {
 	Name              string   `json:"name,omitempty"`
 	PasswordHash      string   `json:"passwd,omitempty"`
 	SSHAuthorizedKeys []string `json:"ssh_authorized_keys,omitempty"`
+}
+
+func (in *Config) DeepCopyInto(out *Config) {
+	*out = *in
+}
+
+func (in *Config) DeepCopy() *Config {
+	if in == nil {
+		return nil
+	}
+	out := new(Config)
+	in.DeepCopyInto(out)
+	return out
 }

--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -117,6 +117,7 @@ func (i *InventoryServer) unauthenticatedResponse(machineRegistration *elm.Machi
 				CACert: i.caCerts,
 			},
 		},
+		Data: machineRegistration.Spec.Config.Data,
 	})
 }
 
@@ -183,11 +184,6 @@ func (i *InventoryServer) writeMachineInventoryCloudConfig(writer io.Writer, inv
 		return err
 	}
 
-	var install config.Install
-	if registration.Spec.Install != nil {
-		install = *registration.Spec.Install
-	}
-
 	return yaml.NewEncoder(writer).Encode(config.Config{
 		Elemental: config.Elemental{
 			Registration: config.Registration{
@@ -200,8 +196,9 @@ func (i *InventoryServer) writeMachineInventoryCloudConfig(writer io.Writer, inv
 				SecretName:      inventory.Name,
 				SecretNamespace: inventory.Namespace,
 			},
-			Install: install,
+			Install: registration.Spec.Config.Elemental.Install,
 		},
+		Data: registration.Spec.Config.Data,
 	})
 }
 
@@ -264,12 +261,4 @@ func getLabels(req *http.Request) (map[string]string, error) {
 	}
 	var labels map[string]string
 	return labels, json.Unmarshal(labelString, &labels)
-}
-
-type WriteFile struct {
-	Encoding    string `json:"encoding,omitempty"`
-	Content     string `json:"content,omitempty"`
-	Owner       string `json:"owner,omitempty"`
-	Path        string `json:"path,omitempty"`
-	Permissions string `json:"permissions,omitempty"`
 }

--- a/tests/catalog/machineregistration.go
+++ b/tests/catalog/machineregistration.go
@@ -24,7 +24,7 @@ type MachineRegistrationSpec struct {
 	MachineName                 string            `yaml:"machineName,omitempty" json:"machineName,omitempty"`
 	MachineInventoryLabels      map[string]string `yaml:"machineInventoryLabels,omitempty" json:"machineInventoryLabels,omitempty"`
 	MachineInventoryAnnotations map[string]string `yaml:"machineInventoryAnnotations,omitempty" json:"machineInventoryAnnotations,omitempty"`
-	Install                     *config.Install   `yaml:"install,omitempty" json:"install,omitempty"`
+	Config                      *config.Config    `yaml:"config,omitempty" json:"config,omitempty"`
 }
 
 type MachineRegistration struct {

--- a/tests/e2e/machineregistration_test.go
+++ b/tests/e2e/machineregistration_test.go
@@ -39,9 +39,16 @@ var _ = Describe("MachineRegistration e2e tests", func() {
 			kubectl.New().Delete("machineregistration", "-n", testRegistrationNamespace, "machine-registration")
 		})
 
-		It("creates a machine registration resource and a URL attaching CA certificate", func() {
-
-			spec := catalog.MachineRegistrationSpec{Install: &config.Install{Device: "/dev/vda", ISO: "https://something.example.com"}}
+		It("creates a machine registration resource and a URL attaching CA certificate", Focus, func() {
+			install := config.Install{Device: "/dev/vda", ISO: "https://something.example.com"}
+			elemental := config.Elemental{Install: install}
+			config := &config.Config{Elemental: elemental, Data: map[string]interface{}{
+				"write_files": map[string]string{
+					"content":  "V2h5IGFyZSB5b3UgY2hlY2tpbmcgdGhpcz8K",
+					"encoding": "b64",
+				},
+			}}
+			spec := catalog.MachineRegistrationSpec{Config: config}
 			mr := catalog.NewMachineRegistration("machine-registration", spec)
 			Eventually(func() error {
 				return k.ApplyYAML(testRegistrationNamespace, "machine-registration", mr)


### PR DESCRIPTION
Return a full config.Config with the Elemental key containing the usual
values used for the elemental-installer and the DATA key with the raw
values, so they can be interpreted by the elemental-installer to produce
the cloud-config to set in the machine.

Otherwise, we cant support cloud-config generic configurations like
write_files without updating the Machineinventory API every time we want
to add one, this way we allow setting an uncapped cloud-config in the
machineinventory and that will be passed down to the elemental-installer

Part of #34 

Would probably require first to get #32 properly set, so we can test this deeply with an authenticated request. Currently the tests only test the registrationURL unauthenticated, which doesn't produce the full output, only a limited output with just the `elemental.registration` fields filled and drops the rest. Once the auth part is fixed (cacerts I guess?) or I understand how to do an authenticated request, I would feel safe to merge this.

Signed-off-by: Itxaka <igarcia@suse.com>