### PR TITLE
Fix building the operator/installer with emulatedTPM

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,25 @@
 project_name: elemental-operator
 builds:
   - main: ./cmd/operator
-    env:
-      - CGO_ENABLED=0
+    binary: elemental-operator
+    id: elemental-operator
     ldflags:
-      - -extldflags -static -w -s
+      - -w -s
+      - -X github.com/rancher/elemental-operator/version.Version={{.Tag}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+  - main: ./cmd/installer
+    binary: elemental-installer
+    id: elemental-installer
+    ldflags:
+      - -w -s
       - -X github.com/rancher/elemental-operator/version.Version={{.Tag}}
     goos:
       - linux

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build: operator installer
 
 .PHONY: operator
 operator:
-	CGO_ENABLED=0 go build -ldflags "-extldflags -static -w -s -X 'github.com/rancher/elemental-operator/version.Version=$(TAG)'" -o build/elemental-operator $(ROOT_DIR)/cmd/operator
+	go build -ldflags "-w -s -X 'github.com/rancher/elemental-operator/version.Version=$(TAG)'" -o build/elemental-operator $(ROOT_DIR)/cmd/operator
 
 .PHONY: installer
 installer:


### PR DESCRIPTION
Fixes the build of operator/installer so they support the emulatedTPM
out of the box (You cant compile them with GCO_ENABLED=0)

Also adds the installer to goreleaser so its also published on new
releases

Signed-off-by: Itxaka <igarcia@suse.com>