### PR TITLE
Log the version, commit and commit date on start

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,7 +16,9 @@ jobs:
         run: |
           git describe --abbrev=0 --tags
           TAG=`git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"`
+          COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
           echo "::set-output name=operator_tag::$TAG"
+          echo "::set-output name=commit_date::$COMMITDATE"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -45,4 +47,6 @@ jobs:
           target: ros-operator
           push: true
           build-args: |
-            VERSION=${{ steps.export_tag.outputs.operator_tag }}
+            TAG=${{ steps.export_tag.outputs.operator_tag }}
+            COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
+            COMMIT=${{ github.sha }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,9 @@ jobs:
         id: export_tag
         run: |
           TAG=`git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"`
+          COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
           echo "::set-output name=operator_tag::$TAG"
+          echo "::set-output name=commit_date::$COMMITDATE"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -49,7 +51,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VERSION=${{ steps.export_tag.outputs.operator_tag }}
+            TAG=${{ steps.export_tag.outputs.operator_tag }}
+            COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
+            COMMIT=${{ github.sha }}
       - name: Make chart
         run: make chart
       - name: Set chart output

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,9 @@ builds:
     id: elemental-operator
     ldflags:
       - -w -s
-      - -X github.com/rancher/elemental-operator/version.Version={{.Tag}}
+      - -X github.com/rancher/elemental-operator/pkg/version.Version={{.Tag}}
+      - -X github.com/rancher/elemental-operator/pkg/version.Commit={{.Commit}}
+      - -X github.com/rancher/elemental-operator/pkg/version.CommitDate={{.CommitDate}}
     goos:
       - linux
     goarch:
@@ -20,7 +22,9 @@ builds:
     id: elemental-installer
     ldflags:
       - -w -s
-      - -X github.com/rancher/elemental-operator/version.Version={{.Tag}}
+      - -X github.com/rancher/elemental-operator/pkg/version.Version={{.Tag}}
+      - -X github.com/rancher/elemental-operator/pkg/version.Commit={{.Commit}}
+      - -X github.com/rancher/elemental-operator/pkg/version.CommitDate={{.CommitDate}}
     goos:
       - linux
     goarch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,15 @@ COPY cmd/operator/main.go /src/
 COPY pkg /src/pkg
 COPY cmd/operator /src/cmd/operator
 # Set arg/env after go mod download, otherwise we invalidate the cached layers due to the commit changing easily
-ARG VERSION=0.0.0
-ENV VERSION=${VERSION}
-RUN go build -ldflags "-extldflags -static -w -s -X github.com/rancher/elemental-operator/version.Version=$VERSION" -o /usr/sbin/elemental-operator ./cmd/operator
+ARG TAG=v0.0.0
+ARG COMMIT=""
+ARG COMMITDATE=""
+RUN go build  \
+    -ldflags "-w -s  \
+    -X github.com/rancher/elemental-operator/pkg/version.Version=$TAG  \
+    -X github.com/rancher/elemental-operator/pkg/version.Commit=$COMMIT  \
+    -X github.com/rancher/elemental-operator/pkg/version.CommitDate=$COMMITDATE"  \
+    -o /usr/sbin/elemental-operator ./cmd/operator
 
 FROM scratch as elemental-operator
 COPY --from=build /usr/sbin/elemental-operator /usr/sbin/elemental-operator

--- a/cmd/operator/operator/root.go
+++ b/cmd/operator/operator/root.go
@@ -48,6 +48,7 @@ func NewOperatorCommand() *cobra.Command {
 			if config.Debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
+			logrus.Infof("Operator version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
 			operatorRun(&config)
 		},
 	}

--- a/cmd/operator/register/root.go
+++ b/cmd/operator/register/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mudler/yip/pkg/schema"
 	cfg "github.com/rancher/elemental-operator/pkg/config"
 	"github.com/rancher/elemental-operator/pkg/tpm"
+	"github.com/rancher/elemental-operator/pkg/version"
 	agent "github.com/rancher/system-agent/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -50,6 +51,7 @@ func NewRegisterCommand() *cobra.Command {
 			if debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
+			logrus.Infof("Operator version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
 			if len(args) == 0 {
 				args = append(args, "/oem")
 			}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,3 +17,5 @@ limitations under the License.
 package version
 
 var Version = "0.1.0-dev"
+var Commit = ""
+var CommitDate = ""


### PR DESCRIPTION
Both for installer and operator, the first thing they now do is log the
version, commit and commit date on start

Fixes #37 

Signed-off-by: Itxaka <igarcia@suse.com>