### PR TITLE
elemental-operator register: enable local plans

### DIFF
--- a/cmd/operator/register/root.go
+++ b/cmd/operator/register/root.go
@@ -204,7 +204,9 @@ func writeYIPConfig(config cfg.Elemental) (string, error) {
 	agentConfig := agent.AgentConfig{
 		WorkDir:            "/var/lib/elemental/agent/work",
 		AppliedPlanDir:     "/var/lib/elemental/agent/applied",
+		LocalPlanDir:       "/var/lib/elemental/agent/plans",
 		RemoteEnabled:      true,
+		LocalEnabled:       true,
 		ConnectionInfoFile: "/var/lib/elemental/agent/elemental_connection.json",
 		PreserveWorkDir:    false,
 	}


### PR DESCRIPTION
Enable local plans execution in the rancher-system-agent.
Just a matter of adding a couple of options to the config created by the elemental-operator.
