### PR TITLE
Change the default machine name to include the UUID

### DIFF
--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -36,7 +36,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-const defaultName = "m-${System Information/Manufacturer}-${System Information/Product Name}-${System Information/Serial Number}"
+const defaultName = "m-${System Information/Manufacturer}-${System Information/Product Name}-${System Information/UUID}"
 
 var (
 	sanitize   = regexp.MustCompile("[^0-9a-zA-Z]")


### PR DESCRIPTION
The current default machine name is made up from SMSBIOS:
- Manufacturer
- Product Name
- Serial Number
for VMs from QEMU anyway the Serial Number is not set, loosing uniqueness for
the machine names (e.g., m-qemu-standard-pc-q35-ich9-2009-not-specified).

Switch the Serial Number to UUID, so that we will have by default unique machine
names also for QEMU VMs.
