### PR TITLE
Fix "make unit-tests"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ validate:
 
 unit-tests-deps:
 	go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
-	go get github.com/onsi/gomega/...
+	go install github.com/onsi/gomega/...
 
 .PHONY: unit-tests
 unit-tests: unit-tests-deps


### PR DESCRIPTION
Just a matter to install and not "get" ginkgo otherwise we break every time a new ginko release is out I guess.

---
$make unit-tests
go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo@latest
go get github.com/onsi/gomega/...
ginkgo -r -v  --covermode=atomic --coverprofile=coverage.out -p -r ./pkg/...
Failed to compile config:

config_suite_test.go:22:2: missing go.sum entry for module providing package github.com/onsi/ginkgo/v2 (imported by github.com/rancher/elemental-operator/pkg/config); to add:
        go get -t github.com/rancher/elemental-operator/pkg/config
FAIL    github.com/rancher/elemental-operator/pkg/config [setup failed]
FAIL

no composite coverage computed: all suites included programatically focused specs

Ginkgo ran 3 suites in 661.375947ms

There were failures detected in the following suites:
  config ./pkg/config [Compilation failure]

Test Suite Failed
make: *** [Makefile:59: unit-tests] Error 1
