### PR TITLE
elemental-operator register: support config files in /oem subdirectories

### DIFF
--- a/cmd/operator/register/root.go
+++ b/cmd/operator/register/root.go
@@ -70,7 +70,11 @@ func NewRegisterCommand() *cobra.Command {
 			for _, arg := range args {
 				viper.AddConfigPath(arg)
 				_ = filepath.WalkDir(arg, func(path string, d fs.DirEntry, err error) error {
-					if !d.IsDir() && filepath.Ext(d.Name()) == ".yaml" {
+					if d.IsDir() {
+						viper.AddConfigPath(path)
+						return nil
+					}
+					if filepath.Ext(d.Name()) == ".yaml" {
 						viper.SetConfigType("yaml")
 						viper.SetConfigName(d.Name())
 						if err := viper.MergeInConfig(); err != nil {


### PR DESCRIPTION
We save the registration config.yaml file under /oem/registration dir.
The function we use to scan the /oem dir for files was not able to deal
with subdirectories:

FATA[0000] failed to read config /oem/registration/config.yaml: Config File "config.yaml" Not Found in "[/oem]"