### PR TITLE
Add a target to setup a clean cluster

### DIFF
--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -26,7 +26,4 @@ set -e
 kubectl cluster-info --context kind-$CLUSTER_NAME
 echo "Sleep to give times to node to populate with all info"
 kubectl wait --for=condition=Ready node/operator-e2e-control-plane
-export EXTERNAL_IP=$(kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type == "InternalIP")].address}')
-export BRIDGE_IP="172.18.0.1"
 kubectl get nodes -o wide
-cd $ROOT_DIR/tests &&  ginkgo -r -v ./e2e

--- a/tests/e2e/do_nothing_test.go
+++ b/tests/e2e/do_nothing_test.go
@@ -1,0 +1,9 @@
+package e2e_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Do nothing", Label("do-nothing"), func() {
+	It("Does nothing", func() {})
+})


### PR DESCRIPTION
This target (ab)uses the ginkgo BeforeSuite to have a ready-to-test
cluster with all prerequisites installed for easy testing.

It will build the docker image for the operator, build the chart
pointing to that image, setup a kind cluster, load the docker image
locally built into the cluster and run an empty test which is done so
the BeforeSuite is run, which installs all the needed charts and the
operator into the system.

Signed-off-by: Itxaka <igarcia@suse.com>