### PR TITLE
[register] Check for path error before doing anything

### DIFF
--- a/cmd/operator/register/root.go
+++ b/cmd/operator/register/root.go
@@ -70,6 +70,9 @@ func NewRegisterCommand() *cobra.Command {
 			for _, arg := range args {
 				viper.AddConfigPath(arg)
 				_ = filepath.WalkDir(arg, func(path string, d fs.DirEntry, err error) error {
+					if err != nil {
+						return err
+					}
 					if !d.IsDir() && filepath.Ext(d.Name()) == ".yaml" {
 						viper.SetConfigType("yaml")
 						viper.SetConfigName(d.Name())
@@ -95,7 +98,6 @@ func NewRegisterCommand() *cobra.Command {
 					config.Elemental.Registration.Labels[parts[0]] = parts[1]
 				}
 			}
-
 			run(config)
 		},
 	}
@@ -116,7 +118,8 @@ func run(config cfg.Config) {
 	registration := config.Elemental.Registration
 
 	if registration.URL == "" {
-		return
+		logrus.Fatal("Registration URL is empty")
+		os.Exit(1)
 	}
 
 	var err error

--- a/cmd/operator/register/root.go
+++ b/cmd/operator/register/root.go
@@ -119,7 +119,6 @@ func run(config cfg.Config) {
 
 	if registration.URL == "" {
 		logrus.Fatal("Registration URL is empty")
-		os.Exit(1)
 	}
 
 	var err error


### PR DESCRIPTION
We were not checking for an error on the path before checking for other
things so that could lead to a runtime error.

This patch just makes sure that before doing anything we check that the
lstat of the path did not give an error, otherwise it skips that path
for any further checks

Also exit with a message on no registrationURL. I cant live without that any longer :D

Signed-off-by: Itxaka <igarcia@suse.com>