### PR TITLE
elemental-operator register: keep system CAs when passing a custom CA

### DIFF
--- a/pkg/tpm/register.go
+++ b/pkg/tpm/register.go
@@ -32,6 +32,7 @@ func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulated
 
 	if len(caCert) > 0 {
 		opts = append(opts, tpm.WithCAs(caCert))
+		opts = append(opts, tpm.AppendCustomCAToSystemCA)
 	}
 
 	header := http.Header{}


### PR DESCRIPTION
When we pass a CACert we enfore the certificate we get from the Register.URL
to be signed by the passed CACert: let's keep also the System CAs in the pool
of allowed CAs in order to accept also imported certificates signed by public
trusted CAs.

Fixes #84 