### PR TITLE
Add version and repository placeholders in helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,9 @@ build-docker-push: build-docker
 chart:
 	mkdir -p  $(ROOT_DIR)/build
 	cp -rf $(ROOT_DIR)/chart $(ROOT_DIR)/build/chart
-	sed -i -e 's/%OPERATOR_VERSION%/${CHART_VERSION}/' $(ROOT_DIR)/build/chart/values.yaml
-	sed -i -e 's|%OPERATOR_REPOSITORY%|${REPO}|' $(ROOT_DIR)/build/chart/values.yaml
-	sed -i -e 's/%OPERATOR_VERSION%/${CHART_VERSION}/' $(ROOT_DIR)/build/chart/Chart.yaml
-	helm package -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/chart
+	sed -i -e 's/tag:.*/tag: '${TAG}'/' $(ROOT_DIR)/build/chart/values.yaml
+	sed -i -e 's|repository:.*|repository: '${REPO}'|' $(ROOT_DIR)/build/chart/values.yaml
+	helm package --version ${CHART_VERSION} --app-version ${GIT_TAG} -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/chart
 	rm -Rf $(ROOT_DIR)/build/chart
 
 validate:

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ build-docker-push: build-docker
 chart:
 	mkdir -p  $(ROOT_DIR)/build
 	cp -rf $(ROOT_DIR)/chart $(ROOT_DIR)/build/chart
-	sed -i -e 's/tag:.*/tag: '${TAG}'/' $(ROOT_DIR)/build/chart/values.yaml
-	sed -i -e 's|repository:.*|repository: '${REPO}'|' $(ROOT_DIR)/build/chart/values.yaml
-	helm package --version ${CHART_VERSION} --app-version ${GIT_TAG} -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/chart
+	sed -i -e 's/%OPERATOR_VERSION%/${CHART_VERSION}/' $(ROOT_DIR)/build/chart/values.yaml
+	sed -i -e 's|%OPERATOR_REPOSITORY%|${REPO}|' $(ROOT_DIR)/build/chart/values.yaml
+	sed -i -e 's/%OPERATOR_VERSION%/${CHART_VERSION}/' $(ROOT_DIR)/build/chart/Chart.yaml
+	helm package -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/chart
 	rm -Rf $(ROOT_DIR)/build/chart
 
 validate:

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,8 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+#!BuildTag: elemental/elemental-operator:%OPERATOR_VERSION%
+#!BuildTag: elemental/elemental-operator:%OPERATOR_VERSION%-build%RELEASE%
 apiVersion: v2
 name: elemental-operator
 description: Rancher Elemental Operator
-version: 0.0.0
-appVersion: 0.0.0
+version: "%OPERATOR_VERSION%"
+appVersion: "%OPERATOR_VERSION%"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/experimental: "true"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-#!BuildTag: elemental/elemental-operator:%OPERATOR_VERSION%
-#!BuildTag: elemental/elemental-operator:%OPERATOR_VERSION%-build%RELEASE%
+#!BuildTag: elemental/elemental-operator:0.0.0-noversion
+#!BuildTag: elemental/elemental-operator:0.0.0-noversion-build%RELEASE%
 apiVersion: v2
 name: elemental-operator
 description: Rancher Elemental Operator
-version: "%OPERATOR_VERSION%"
-appVersion: "%OPERATOR_VERSION%"
+version: 0.0.0-noversion
+appVersion: v0.0.0-noversion
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/experimental: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,9 +2,8 @@ image:
   empty: rancher/pause:3.1
   # elemental-operator image is also build on:
   #   registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-operator
-  #   quay.io/costoolkit/elemental-operator
-  repository: "%OPERATOR_REPOSITORY%"
-  tag: "%OPERATOR_VERSION%"
+  repository: quay.io/costoolkit/elemental-operator
+  tag: 0.0.0-noversion
   imagePullPolicy: IfNotPresent
 
 # http[s] proxy server

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,8 +1,10 @@
 image:
   empty: rancher/pause:3.1
-  # elemental-operator image is also build on registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-operator
-  repository: quay.io/costoolkit/elemental-operator
-  tag: ""
+  # elemental-operator image is also build on:
+  #   registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-operator
+  #   quay.io/costoolkit/elemental-operator
+  repository: "%OPERATOR_REPOSITORY%"
+  tag: "%OPERATOR_VERSION%"
   imagePullPolicy: IfNotPresent
 
 # http[s] proxy server


### PR DESCRIPTION
This commit adds repository and version placeholders in Chart.yaml
and values.yaml files so they can be dynamically replaced by some
sort of automation at build time.

Signed-off-by: David Cassany <dcassany@suse.com>