### PR TITLE
Bump rancher version

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -102,7 +102,7 @@ var _ = BeforeSuite(func() {
 
 	rancherVersion := os.Getenv("RANCHER_VERSION")
 	if rancherVersion == "" {
-		rancherVersion = "2.6.4"
+		rancherVersion = "2.6.6"
 	}
 
 	externalIP = os.Getenv("EXTERNAL_IP")


### PR DESCRIPTION
Due to our integration with rancher-system-agent we need to bump the
version, otherwise the rancher-system-agent will fail to launch

Signed-off-by: Itxaka <igarcia@suse.com>