### PR TITLE
Drop setting a custom providerID

### DIFF
--- a/pkg/controllers/machineinventoryselector/bootstrap.go
+++ b/pkg/controllers/machineinventoryselector/bootstrap.go
@@ -106,11 +106,6 @@ func (h *handler) getBootstrapPlan(selector *v1beta1.MachineInventorySelector, i
 				Path:        "/var/lib/rancher/bootstrap.sh",
 				Permissions: "0700",
 			},
-			{
-				Path:        "/etc/rancher/rke2/config.yaml.d/40-elemental.yaml",
-				Permissions: "0600",
-				Content:     base64.StdEncoding.EncodeToString([]byte("kubelet-arg: provider-id=" + selector.Spec.ProviderID)),
-			},
 		},
 		OneTimeInstructions: []applyinator.OneTimeInstruction{
 			{

--- a/pkg/controllers/machineinventoryselector/controller.go
+++ b/pkg/controllers/machineinventoryselector/controller.go
@@ -18,7 +18,6 @@ package machineinventoryselector
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
@@ -105,7 +104,6 @@ func (h *handler) readyHandler(obj *v1beta1.MachineInventorySelector, status v1b
 		return status, err
 	}
 
-	obj.Spec.ProviderID = "elemental://" + inventory.Name
 	obj, err = h.MachineInventorySelectors.Update(obj)
 	if err != nil {
 		return status, err
@@ -213,17 +211,6 @@ func (h *handler) getInventorySelectorOwner(obj metav1.Object) (*v1beta1.Machine
 	}
 
 	return nil, nil
-}
-
-//nolint:unused
-func (h *handler) getSelectorInventory(selector *v1beta1.MachineInventorySelector) (*v1beta1.MachineInventory, error) {
-	providerID := strings.Replace(selector.Spec.ProviderID, "elemental://", "", 1)
-
-	if providerID == "" {
-		return nil, nil
-	}
-
-	return h.MachineInventoryCache.Get(selector.Namespace, providerID)
 }
 
 func (h *handler) getMachineOwner(obj metav1.Object) (*v1beta12.Machine, error) {


### PR DESCRIPTION
Not usre why we were using the elemental:// providerID while this should
be something like k3s://

Not only that but it was blocking the correct health check of the
clusters due to not finding the provider.

Also drops the provider config override from rke2 as it was setting it
to an empty value. We should be able to restore if it proves to be
needed but doesnt seem to.

Signed-off-by: Itxaka <igarcia@suse.com>