### PR TITLE
operator: drop duplicated MachineInventory init code

### DIFF
--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -69,8 +69,6 @@ func (i *InventoryServer) ServeHTTP(resp http.ResponseWriter, req *http.Request)
 	}
 
 	if inventory.CreationTimestamp.IsZero() {
-		inventory.ObjectMeta.Labels = registration.Spec.MachineInventoryLabels
-		inventory.ObjectMeta.Annotations = registration.Spec.MachineInventoryAnnotations
 		inventory, err = i.createMachineInventory(req, inventory, registration)
 		if err != nil {
 			logrus.Error("error creating machine inventory: ", err)


### PR DESCRIPTION
Labels and Annotations are initialized the same way in
createMachineInventory()