### PR TITLE
Set a fixed name config for rke/k3s deployments

### DIFF
--- a/pkg/controllers/machineinventoryselector/bootstrap.go
+++ b/pkg/controllers/machineinventoryselector/bootstrap.go
@@ -106,6 +106,16 @@ func (h *handler) getBootstrapPlan(selector *v1beta1.MachineInventorySelector, i
 				Path:        "/var/lib/rancher/bootstrap.sh",
 				Permissions: "0700",
 			},
+			{
+				Content:     base64.StdEncoding.EncodeToString([]byte("node-name: " + inventory.Name)),
+				Path:        "/etc/rancher/rke2/config.yaml.d/99-elemental-name.yaml",
+				Permissions: "0600",
+			},
+			{
+				Content:     base64.StdEncoding.EncodeToString([]byte("node-name: " + inventory.Name)),
+				Path:        "/etc/rancher/k3s/config.yaml.d/99-elemental-name.yaml",
+				Permissions: "0600",
+			},
 		},
 		OneTimeInstructions: []applyinator.OneTimeInstruction{
 			{


### PR DESCRIPTION
Fixes https://github.com/rancher/elemental/issues/221

Looks like the name change once rebooted was causing more problems that what it looked like. On the first deployment, some of the pods would be launched with the hostname as part of them, i.e. `cloud-controller-manager-m-qemu-standard-pc-q35-ich9-2009-1d566d99-d81a-49ae-b0bb-3` and that was ok, but the deployment would also change the node name to be `rancher-NUMBERS` which only took place after a restart.

The deployment would then try to recover, and bring up missing pods with that name, but would also bring up the old pods with the old name, causing some pods to fight for resources or directly crash constantly.

This patch adds an extra config to the k3s/rk2 configurations to set the `node-name` for the deployment agents and pods to the `inventory.Name`, so no matter how many restarts or name changes the machine suffers, the agents will always use that node-name for any config that it needs.

Signed-off-by: Itxaka <igarcia@suse.com>