### PR TITLE
Push master merges to elemental-operator-ci

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,6 +1,8 @@
 name: Docker build and push
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 jobs:
@@ -19,7 +21,8 @@ jobs:
           COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
           echo "::set-output name=operator_tag::$TAG"
           echo "::set-output name=commit_date::$COMMITDATE"
-      - name: Docker meta
+      - name: Docker meta for tag
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -27,6 +30,16 @@ jobs:
             quay.io/costoolkit/elemental-operator
           tags: |
             type=semver,pattern={{raw}}
+      - name: Docker meta for master
+        if: contains(github.ref, 'refs/heads/main')
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            quay.io/costoolkit/elemental-operator-ci
+          tags: |
+            type=sha,format=short,prefix=${{ steps.export_tag.outputs.operator_tag }}-
+            type=raw,value=latest
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,12 +37,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to Quay
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_TOKEN }}
       - name: Build image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -9,6 +9,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   push-docker:
+    env:
+      REPO: ttl.sh/elemental-operator-ci
     runs-on: ubuntu-latest
     outputs:
       chart_name: ${{ steps.chart.outputs.chart_name }}
@@ -29,7 +31,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            quay.io/costoolkit/elemental-operator-ci
+            ${{ env.REPO }}
           tags: |
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.operator_tag }}-
       - name: Set up Docker Buildx
@@ -55,7 +57,7 @@ jobs:
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
             COMMIT=${{ github.sha }}
       - name: Make chart
-        run: make chart
+        run: REPO=${{ env.REPO }} make chart
       - name: Set chart output
         id: chart
         run: |


### PR DESCRIPTION
On master merge, push the image also to elemental-operator-ci adding
also the latest tag, so it can be tracked by external sources and alwasy
use the latest master merge

Not that in the case of the elemental-operator we also push the PRs to
elemental-operator-ci but those are only used temporarily for e2e
testing and latest tag will only track master merges

Signed-off-by: Itxaka <igarcia@suse.com>