### PR TITLE
Set the proper namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Elemental operator can be added to a cluster running Rancher Multi Cluster
 Management server.  It is a helm chart and can be installed as follows:
 
 ```bash
-helm -n cattle-elemental-operator-system install --create-namespace elemental-operator https://github.com/rancher/elemental-operator/releases/download/v0.1.0/elemental-operator-0.1.0.tgz
+helm -n cattle-elemental-system install --create-namespace elemental-operator https://github.com/rancher/elemental-operator/releases/download/v0.1.0/elemental-operator-0.1.0.tgz
 ```
 
 ## Managing Upgrades

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 0.0.0
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/experimental: "true"
-  catalog.cattle.io/namespace: cattle-elemental-operator-system
+  catalog.cattle.io/namespace: cattle-elemental-system
   catalog.cattle.io/release-name: elemental-operator
   catalog.cattle.io/provides-gvr: elemental.cattle.io/v1beta1
   catalog.cattle.io/os: linux

--- a/tests/e2e/machineregistration_test.go
+++ b/tests/e2e/machineregistration_test.go
@@ -29,14 +29,12 @@ import (
 	"github.com/rancher/elemental-operator/tests/catalog"
 )
 
-const testRegistrationNamespace = "cattle-elemental-operator-system"
-
 var _ = Describe("MachineRegistration e2e tests", func() {
 	k := kubectl.New()
 	Context("registration", func() {
 
 		AfterEach(func() {
-			kubectl.New().Delete("machineregistration", "-n", testRegistrationNamespace, "machine-registration")
+			kubectl.New().Delete("machineregistration", "-n", operatorNamespace, "machine-registration")
 		})
 
 		It("creates a machine registration resource and a URL attaching CA certificate", func() {
@@ -51,12 +49,12 @@ var _ = Describe("MachineRegistration e2e tests", func() {
 			spec := catalog.MachineRegistrationSpec{Config: config}
 			mr := catalog.NewMachineRegistration("machine-registration", spec)
 			Eventually(func() error {
-				return k.ApplyYAML(testRegistrationNamespace, "machine-registration", mr)
+				return k.ApplyYAML(operatorNamespace, "machine-registration", mr)
 			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
 
 			var url string
 			Eventually(func() string {
-				e, err := kubectl.GetData(testRegistrationNamespace, "machineregistration", "machine-registration", `jsonpath={.status.registrationURL}`)
+				e, err := kubectl.GetData(operatorNamespace, "machineregistration", "machine-registration", `jsonpath={.status.registrationURL}`)
 				if err != nil {
 					fmt.Println(err)
 				}


### PR DESCRIPTION
We are trying to get the cattle-elemental-system namespace into rancher
as a system namespace, while we have a different namespace around,
including in the elemental examples.

This changes the wrong namespace into the proper one

Signed-off-by: Itxaka <igarcia@suse.com>