### PR TITLE
Bundle support bin with register

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as build
+FROM golang:1.17-alpine AS build
 ENV CGO_ENABLED=0
 WORKDIR /src
 COPY go.mod go.sum /src/
@@ -7,7 +7,10 @@ COPY cmd/operator/main.go /src/
 COPY pkg /src/pkg
 COPY cmd/operator /src/cmd/operator
 COPY cmd/register /src/cmd/register
+COPY cmd/support /src/cmd/support
 # Set arg/env after go mod download, otherwise we invalidate the cached layers due to the commit changing easily
+
+FROM build AS build-operator
 ARG TAG=v0.0.0
 ARG COMMIT=""
 ARG COMMITDATE=""
@@ -18,20 +21,31 @@ RUN go build  \
     -X github.com/rancher/elemental-operator/pkg/version.CommitDate=$COMMITDATE"  \
     -o /usr/sbin/elemental-operator ./cmd/operator
 
+FROM build AS build-register
+ARG TAG=v0.0.0
+ARG COMMIT=""
+ARG COMMITDATE=""
 RUN go build  \
     -ldflags "-w -s  \
     -X github.com/rancher/elemental-operator/pkg/version.Version=$TAG  \
     -X github.com/rancher/elemental-operator/pkg/version.Commit=$COMMIT  \
     -X github.com/rancher/elemental-operator/pkg/version.CommitDate=$COMMITDATE"  \
     -o /usr/sbin/elemental-register ./cmd/register
+RUN go build  \
+    -ldflags "-w -s  \
+    -X github.com/rancher/elemental-operator/pkg/version.Version=$TAG  \
+    -X github.com/rancher/elemental-operator/pkg/version.Commit=$COMMIT  \
+    -X github.com/rancher/elemental-operator/pkg/version.CommitDate=$COMMITDATE"  \
+    -o /usr/sbin/elemental-support ./cmd/support
 
 
-FROM scratch as elemental-operator
+FROM scratch AS elemental-operator
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /usr/sbin/elemental-operator /usr/sbin/elemental-operator
+COPY --from=build-operator /usr/sbin/elemental-operator /usr/sbin/elemental-operator
 ENTRYPOINT ["/usr/sbin/elemental-operator"]
 
-FROM scratch as elemental-register
+FROM scratch AS elemental-register
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /usr/sbin/elemental-register /usr/sbin/elemental-register
+COPY --from=build-register /usr/sbin/elemental-register /usr/sbin/elemental-register
+COPY --from=build-register /usr/sbin/elemental-support /usr/sbin/elemental-support
 ENTRYPOINT ["/usr/sbin/elemental-register"]


### PR DESCRIPTION
It makes sense to bundle the support binary in the register container as
they are used on the nodes

Also separate the go build stuff between operator and register so it
doest take that much time

Signed-off-by: Itxaka <igarcia@suse.com>