### PR TITLE
Remove default value for flag and expand description

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,7 +2,7 @@ image:
   empty: rancher/pause:3.1
   # elemental-operator image is also build on registry.opensuse.org/isv/rancher/elemental/teal52/15.3/rancher/elemental-operator
   repository: quay.io/costoolkit/elemental-operator
-  tag: ""
+  tag: latest
   imagePullPolicy: IfNotPresent
 
 # http[s] proxy server

--- a/cmd/operator/operator/root.go
+++ b/cmd/operator/operator/root.go
@@ -62,7 +62,7 @@ func NewOperatorCommand() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVar(&config.SyncNamespaces, "sync-namespaces", []string{}, "namespace to watch for machine registrations")
 	_ = viper.BindPFlag("sync-namespaces", cmd.PersistentFlags().Lookup("sync-namespaces"))
 
-	cmd.PersistentFlags().StringVar(&config.OperatorImage, "operator-image", "rancher/elemental-operator:"+version.Version, "this image")
+	cmd.PersistentFlags().StringVar(&config.OperatorImage, "operator-image", "", "Operator image. Used to gather the results from the syncer by running the 'display' command")
 	_ = viper.BindPFlag("operator-image", cmd.PersistentFlags().Lookup("operator-image"))
 	_ = cobra.MarkFlagRequired(cmd.PersistentFlags(), "operator-image")
 


### PR DESCRIPTION
Make sure we have a decent description for the --operator-image flag as
that is used down the line by the syncer to run the display command and
gather the results from the version syncer.

Also remove the default value for the flag. It makes no sense to have a
default value if we mark a flag as required, as that value will always
be overwritten by the flag.

Fixes #119 

Signed-off-by: Itxaka <igarcia@suse.com>