### PR TITLE
Store binary artifacts on PR/master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,3 +24,18 @@ jobs:
             ${{ runner.os }}-build-go-${{ hashFiles('**/go.sum') }}
       - name: Build
         run: make build
+      - name: Store operator binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: elemental-operator
+          path: build/elemental-operator
+      - name: Store register binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: elemental-register
+          path: build/elemental-register
+      - name: Store support binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: elemental-support
+          path: build/elemental-support


### PR DESCRIPTION
Useful to create special binaries and give them to people for quick
testing if we store those built binaries from PRs/main branch

Signed-off-by: Itxaka <igarcia@suse.com>