### PR TITLE
[tests] fix nginx deploy url

### DIFF
--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -172,7 +172,7 @@ var _ = BeforeSuite(func() {
 				return
 			}
 			kubectl.CreateNamespace("ingress-nginx")
-			err := kubectl.Apply("ingress-nginx", "https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/1.22/deploy.yaml")
+			err := kubectl.Apply("ingress-nginx", "https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml")
 			Expect(err).ToNot(HaveOccurred())
 
 			err = k.WaitForNamespaceWithPod("ingress-nginx", "app.kubernetes.io/component=controller")


### PR DESCRIPTION
Since https://github.com/kubernetes/ingress-nginx/pull/8877 was merged
the ingress-nginx project does not longer provide versioned deploy files

This should fix our end2end tests

Signed-off-by: Itxaka <igarcia@suse.com>