### PR TITLE
Split header into 7Kb of data

### DIFF
--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -244,12 +244,24 @@ func buildName(data map[string]interface{}, name string) string {
 }
 
 func getSMBios(req *http.Request) (map[string]interface{}, error) {
-	smbios := req.Header.Get("X-Cattle-Smbios")
+	var smbios string
+	// 200 * 875bytes per header = 175Kb of smbios data, should be enough?
+	for i := 1; i <= 200; i++ {
+		header := req.Header.Get(fmt.Sprintf("X-Cattle-Smbios-%d", i))
+		if header == "" {
+			break
+		}
+		smbios = smbios + header
+	}
+
 	if smbios == "" {
+		logrus.Debug("No smbios headers")
 		return nil, nil
 	}
+
 	smbiosData, err := base64.StdEncoding.DecodeString(smbios)
 	if err != nil {
+		logrus.Error("Error decoding smbios string")
 		return nil, err
 	}
 	data := map[string]interface{}{}

--- a/pkg/tpm/register.go
+++ b/pkg/tpm/register.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -51,7 +53,20 @@ func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulated
 		}
 
 		_ = b64Enc.Close()
-		header.Set("X-Cattle-Smbios", buf.String())
+
+		chunk := make([]byte, 875) //the chunk size
+		part := 1
+		for {
+			n, err := buf.Read(chunk)
+			if err != nil {
+				if err != io.EOF {
+					return nil, errors.Wrap(err, "failed to read file in chunks")
+				}
+				break
+			}
+			header.Set(fmt.Sprintf("X-Cattle-Smbios-%d", part), string(chunk[0:n]))
+			part++
+		}
 	}
 
 	if len(labels) > 0 {


### PR DESCRIPTION
This generates several X-Cattle-Smbios-NUMER headers when sending the
data to the operator in order to limit the max size of each individual
header to 7Kb. By default nginx is configured with a max of 8Kb header
and will return a 400 error if the headers excess that size.

As we currently use a GET+Websocket to go trougth the challenge/response
of TPM, this is the easiest implementation to workaround the issue.

Signed-off-by: Itxaka <igarcia@suse.com>