### PR TITLE
machine registration connectivity rework - part I

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -109,11 +109,9 @@ func (i *InventoryServer) getRancherCACert() string {
 func (i *InventoryServer) getRancherServerURL() (string, error) {
 	setting, err := i.settingCache.Get("server-url")
 	if err != nil {
-		logrus.Errorf("Error getting server-url setting: %s", err.Error())
 		return "", err
 	}
 	if setting.Value == "" {
-		logrus.Error("server-url is not set")
 		return "", fmt.Errorf("server-url is not set")
 	}
 	return setting.Value, nil

--- a/pkg/tpm/auth_tpm.go
+++ b/pkg/tpm/auth_tpm.go
@@ -18,11 +18,9 @@ package tpm
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/go-attestation/attest"
@@ -31,7 +29,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	elm "github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
-	"github.com/rancher/wrangler/pkg/merr"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -105,77 +102,36 @@ func writeRead(conn *websocket.Conn, input []byte) ([]byte, error) {
 	return ioutil.ReadAll(reader)
 }
 
-func upgrade(resp http.ResponseWriter, req *http.Request) (*websocket.Conn, error) {
-	upgrader := websocket.Upgrader{
-		HandshakeTimeout: 5 * time.Second,
-		CheckOrigin:      func(r *http.Request) bool { return true },
-	}
-
-	conn, err := upgrader.Upgrade(resp, req, nil)
-	if err != nil {
-		return nil, err
-	}
-	_ = conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-	_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
-
-	return conn, err
-}
-
-func (a *AuthServer) Authenticate(resp http.ResponseWriter, req *http.Request, registerNamespace string) (*elm.MachineInventory, bool, io.WriteCloser, error) {
-	if !websocket.IsWebSocketUpgrade(req) {
-		logrus.Debugf("plain HTTP request from %s", req.RemoteAddr)
-		return nil, true, nil, nil
-	}
-
+func (a *AuthServer) Authenticate(conn *websocket.Conn, req *http.Request, registerNamespace string) (*elm.MachineInventory, bool, error) {
 	header := req.Header.Get("Authorization")
 	if !strings.HasPrefix(header, "Bearer TPM") {
 		logrus.Debugf("websocket connection missing Authorization header from %s", req.RemoteAddr)
-		return nil, true, nil, nil
+		return nil, true, nil
 	}
 
 	ek, attestationData, err := gotpm.GetAttestationData(header)
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, err
 	}
 
 	machine, err := a.validHash(ek, registerNamespace)
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, err
 	}
 
 	secret, challenge, err := gotpm.GenerateChallenge(ek, attestationData)
 	if err != nil {
-		return nil, false, nil, err
-	}
-
-	conn, err := upgrade(resp, req)
-	if err != nil {
-		return nil, false, nil, err
+		return nil, false, err
 	}
 
 	challResp, err := writeRead(conn, challenge)
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, err
 	}
 
 	if err := gotpm.ValidateChallenge(secret, challResp); err != nil {
-		return nil, false, nil, err
+		return nil, false, err
 	}
 
-	writer, err := conn.NextWriter(websocket.BinaryMessage)
-	return machine, false, &responseWriter{
-		WriteCloser: writer,
-		conn:        conn,
-	}, err
-}
-
-type responseWriter struct {
-	io.WriteCloser
-	conn *websocket.Conn
-}
-
-func (r *responseWriter) Close() error {
-	err := r.WriteCloser.Close()
-	err2 := r.conn.Close()
-	return merr.NewErrors(err, err2)
+	return machine, false, nil
 }

--- a/pkg/tpm/auth_tpm.go
+++ b/pkg/tpm/auth_tpm.go
@@ -122,8 +122,14 @@ func upgrade(resp http.ResponseWriter, req *http.Request) (*websocket.Conn, erro
 }
 
 func (a *AuthServer) Authenticate(resp http.ResponseWriter, req *http.Request, registerNamespace string) (*elm.MachineInventory, bool, io.WriteCloser, error) {
+	if !websocket.IsWebSocketUpgrade(req) {
+		logrus.Debugf("plain HTTP request from %s", req.RemoteAddr)
+		return nil, true, nil, nil
+	}
+
 	header := req.Header.Get("Authorization")
 	if !strings.HasPrefix(header, "Bearer TPM") {
+		logrus.Debugf("websocket connection missing Authorization header from %s", req.RemoteAddr)
 		return nil, true, nil, nil
 	}
 


### PR DESCRIPTION
Till now the TPM package was in charge to upgrade the HTTP connection and manage the websocket one.
This PR moves the connection management (server side) to the server package to split the connection management from TPM authentication.
This will allow us later (part II) to make it easier to pass the smbios data and the labels through the websocket channel instead of abusing HTTP headers.
This PR doesn't introduce any functional change, so doesn't change (nor break) current websocket communication pattern. 
Related to https://github.com/rancher/elemental-operator/issues/5
Partially fixes https://github.com/rancher/elemental-operator/issues/130