### PR TITLE
 machine registration connectivity rework - part II

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/mudler/yip/pkg/schema"
 	"github.com/rancher/elemental-operator/pkg/config"
-	"github.com/rancher/elemental-operator/pkg/tpm"
+	"github.com/rancher/elemental-operator/pkg/register"
 	"github.com/rancher/elemental-operator/pkg/version"
 	agent "github.com/rancher/system-agent/pkg/config"
 	"github.com/sanity-io/litter"
@@ -156,7 +156,7 @@ func run(config config.Config) {
 	}
 
 	for {
-		data, err = tpm.Register(registration.URL, caCert, !registration.NoSMBIOS, registration.EmulateTPM, registration.EmulatedTPMSeed, registration.Labels)
+		data, err = register.Register(registration.URL, caCert, !registration.NoSMBIOS, registration.EmulateTPM, registration.EmulatedTPMSeed, registration.Labels)
 		if err != nil {
 			logrus.Error("failed to register machine inventory: ", err)
 			time.Sleep(time.Second * 5)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220624082733-2dbd4e2d2b95
-	github.com/rancher-sandbox/go-tpm v0.0.0-20220512105546-a8efc2a6448e
+	github.com/rancher-sandbox/go-tpm v0.0.0-20220823075603-d273b298fcda
 	github.com/rancher/fleet/pkg/apis v0.0.0-20220318160658-4dc66c946ca2
 	github.com/rancher/lasso v0.0.0-20210709145333-6c6cd7fd6607
 	github.com/rancher/rancher/pkg/apis v0.0.0-20211013185633-a636bda2a00e // indirect

--- a/go.sum
+++ b/go.sum
@@ -1226,6 +1226,8 @@ github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220624082733-2dbd4e2d2b95 h1
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220624082733-2dbd4e2d2b95/go.mod h1:rZj2a+V44LvtFVH/vsFXtHYIWMP1Q9aSrl6RGLbk49A=
 github.com/rancher-sandbox/go-tpm v0.0.0-20220512105546-a8efc2a6448e h1:MFYTJkPeV3Lq6bIBTwyCv2+sKW2kV0vfe820v6n0Vig=
 github.com/rancher-sandbox/go-tpm v0.0.0-20220512105546-a8efc2a6448e/go.mod h1:cUw+h4wm01VdavMOjUMVQ5m/b2oiOjZ7gweI8AlybO4=
+github.com/rancher-sandbox/go-tpm v0.0.0-20220823075603-d273b298fcda h1:TMkKDQTmjYpxl8/3XDh0oAJDvjM0C0vtQYdGs2I9MoE=
+github.com/rancher-sandbox/go-tpm v0.0.0-20220823075603-d273b298fcda/go.mod h1:cUw+h4wm01VdavMOjUMVQ5m/b2oiOjZ7gweI8AlybO4=
 github.com/rancher/aks-operator v1.0.2 h1:R6niUq/IlhzKpzRFmRR9YMiMePJh1flEqFO86us7OMY=
 github.com/rancher/aks-operator v1.0.2/go.mod h1:Nafxvj+HQOMXb418Oj6eFVOUf0fnq8e4RBqi9S+Q5WQ=
 github.com/rancher/apiserver v0.0.0-20210922180056-297b6df8d714/go.mod h1:8W0EwaR9dH5NDFw6mpAX437D0q+EZqKWbZyX71+z2WI=

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -1,0 +1,150 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package register
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
+	"github.com/rancher/elemental-operator/pkg/dmidecode"
+	"github.com/rancher/elemental-operator/pkg/tpm"
+	"github.com/sirupsen/logrus"
+)
+
+func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulatedSeed int64, labels map[string]string) ([]byte, error) {
+
+	dialer := websocket.DefaultDialer
+
+	if len(caCert) > 0 {
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+		pool.AppendCertsFromPEM(caCert)
+		dialer.TLSClientConfig = &tls.Config{RootCAs: pool}
+	}
+
+	tpmAuth := &tpm.AuthClient{}
+	if emulatedTPM {
+		logrus.Info("Starting TPM emulation")
+		tpmAuth.EmulateTPM(emulatedSeed)
+	}
+	authToken, tpmHash, err := tpmAuth.GetAuthToken()
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate authentication token from TPM: %w", err)
+	}
+
+	wsURL := strings.Replace(url, "http", "ws", 1)
+	logrus.Infof("Using TPMHash %s to dial %s", tpmHash, wsURL)
+
+	header := http.Header{}
+	header.Add("Authorization", authToken)
+	if smbios {
+		err = addSMBIOSHeaders(&header)
+		if err != nil {
+			return nil, fmt.Errorf("add SMBIOS headers: %w", err)
+		}
+	}
+	if len(labels) > 0 {
+		err = addLabelsHeaders(&header, labels)
+		if err != nil {
+			return nil, fmt.Errorf("add labels in header: %w", err)
+		}
+	}
+
+	conn, resp, err := dialer.Dial(wsURL, header)
+	if err != nil {
+		if resp != nil {
+			if resp.StatusCode == http.StatusUnauthorized {
+				data, err := ioutil.ReadAll(resp.Body)
+				if err == nil {
+					return nil, errors.New(string(data))
+				}
+			} else {
+				return nil, fmt.Errorf("%w (Status: %s)", err, resp.Status)
+			}
+		}
+		return nil, err
+	}
+	defer conn.Close()
+
+	err = tpmAuth.Init(conn)
+	if err != nil {
+		return nil, fmt.Errorf("failed TPM based authentication: %w", err)
+	}
+
+	_, msg, err := conn.NextReader()
+	if err != nil {
+		return nil, fmt.Errorf("reading elemental config: %w", err)
+	}
+
+	return ioutil.ReadAll(msg)
+}
+
+func addSMBIOSHeaders(header *http.Header) error {
+	data, err := dmidecode.Decode()
+	if err != nil {
+		return errors.Wrap(err, "failed to read dmidecode data")
+	}
+
+	var buf bytes.Buffer
+	b64Enc := base64.NewEncoder(base64.StdEncoding, &buf)
+
+	if err = json.NewEncoder(b64Enc).Encode(data); err != nil {
+		return errors.Wrap(err, "failed to encode dmidecode data")
+	}
+
+	_ = b64Enc.Close()
+
+	chunk := make([]byte, 875) //the chunk size
+	part := 1
+	for {
+		n, err := buf.Read(chunk)
+		if err != nil {
+			if err != io.EOF {
+				return errors.Wrap(err, "failed to read file in chunks")
+			}
+			break
+		}
+		header.Set(fmt.Sprintf("X-Cattle-Smbios-%d", part), string(chunk[0:n]))
+		part++
+	}
+	return nil
+}
+
+func addLabelsHeaders(header *http.Header, labels map[string]string) error {
+	var buf bytes.Buffer
+	b64Enc := base64.NewEncoder(base64.StdEncoding, &buf)
+
+	if err := json.NewEncoder(b64Enc).Encode(labels); err != nil {
+		return errors.Wrap(err, "failed to encode labels")
+	}
+
+	_ = b64Enc.Close()
+	header.Set("X-Cattle-Labels", buf.String())
+	return nil
+}


### PR DESCRIPTION
This is the client-side equivalent of https://github.com/rancher/elemental-operator/pull/140.
~~Note that this needs first that https://github.com/rancher-sandbox/go-tpm/pull/5 got merged, then this branch will be updated with the new go-tpm version (for this reason got the `blocked` flag).~~ _(merged, blocked flag removed)_

register: take control of the registration process
Till now, the attestation and communication with the elemental operator
were all demanded to the github.com/rancher-sandbox/go-tpm package.
Split TPM attestation from the communication with the elemental operator
demanding TPM authentication to the external library while taking full
control of the communication with the operator.

This doesn't introduce functional changes (so it will keep retrocompatibility
with the current elemental operator) and is a preparatory step to address
rancher/elemental-operator#5