### PR TITLE
Enable deploying operator replicas

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -67,11 +67,14 @@ jobs:
     strategy:
       matrix:
         kubernetes: [ "v1.22.7" ]
+        replicas: ["1", "2"]
     runs-on: ubuntu-latest
     needs: push-docker
+    name: k8s ${{ matrix.kubernetes }} - ${{ matrix.replicas }} replicas
     env:
       CHART: ${{ github.workspace }}/build/${{ needs.push-docker.outputs.chart_name }}
       KUBE_VERSION: ${{ matrix.kubernetes }}
+      OPERATOR_REPLICAS: ${{ matrix.replicas }}
     steps:
       - uses: actions/checkout@v2
       - name: Download chart

--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -1,9 +1,9 @@
 kind: APIService
 apiVersion: management.cattle.io/v3
 metadata:
-  name: elemental-operator
+  name: {{ .Release.Name }}
 spec:
-  secretName: elemental-operator
+  secretName: {{ .Release.Name }}
   secretNamespace: {{ .Release.Namespace }}
   pathPrefixes:
   - /elemental/

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,8 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: elemental-operator
+  name: {{ .Release.Name }}
 spec:
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: elemental-operator
@@ -21,7 +22,7 @@ spec:
         - name: HTTPS_PROXY
           value: {{ .Values.proxy }}
         {{- end }}
-        name: elemental-operator
+        name: {{ .Release.Name }}
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
         image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         args:
@@ -43,7 +44,7 @@ spec:
         - --default-registry
         - {{ .Values.global.cattle.systemDefaultRegistry | quote }}
         {{- end }}
-      serviceAccountName: elemental-operator
+      serviceAccountName: {{ .Release.Name }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: elemental-operator
+  name: {{ .Release.Name }}
 rules:
 - apiGroups:
     - management.cattle.io
@@ -94,12 +94,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: elemental-operator
+  name: {{ .Release.Name }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: elemental-operator
+  name: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: elemental-operator
+  name: {{ .Release.Name }}
   namespace: {{.Release.Namespace}}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: elemental-operator
+  name: {{ .Release.Name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,9 @@ image:
   tag: latest
   imagePullPolicy: IfNotPresent
 
+# number of operator replicas to deploy
+replicas: 1
+
 # http[s] proxy server
 # proxy: http://<username>@<password>:<url>:<port>
 

--- a/tests/e2e/machineregistration_test.go
+++ b/tests/e2e/machineregistration_test.go
@@ -35,6 +35,7 @@ var _ = Describe("MachineRegistration e2e tests", func() {
 
 		AfterEach(func() {
 			kubectl.New().Delete("machineregistration", "-n", operatorNamespace, "machine-registration")
+
 		})
 
 		It("creates a machine registration resource and a URL attaching CA certificate", func() {
@@ -48,6 +49,7 @@ var _ = Describe("MachineRegistration e2e tests", func() {
 			}}
 			spec := catalog.MachineRegistrationSpec{Config: config}
 			mr := catalog.NewMachineRegistration("machine-registration", spec)
+
 			Eventually(func() error {
 				return k.ApplyYAML(operatorNamespace, "machine-registration", mr)
 			}, 2*time.Minute, 2*time.Second).ShouldNot(HaveOccurred())
@@ -79,6 +81,7 @@ var _ = Describe("MachineRegistration e2e tests", func() {
 					ContainSubstring("END CERTIFICATE"),
 				),
 			)
+
 			// TODO: We should check that the install values that we passed are indeed returned by the registration?
 		})
 	})


### PR DESCRIPTION
Enables deploying either multiple operators.

Changes tests to account and test this

Chart changes:
 - Make any fixed names default to the release name. As release name has
   to be unique per namespace, this is a good practice instead of
   hardcoding whatever name we want. This shouldnt affect anything as
   the full chart uses that by default now.

Signed-off-by: Itxaka <igarcia@suse.com>