### PR TITLE
Fix secretname for the apiService

### DIFF
--- a/chart/templates/apiservice.yaml
+++ b/chart/templates/apiservice.yaml
@@ -3,7 +3,7 @@ apiVersion: management.cattle.io/v3
 metadata:
   name: {{ .Release.Name }}
 spec:
-  secretName: {{ .Release.Name }}
+  secretName: elemental-operator
   secretNamespace: {{ .Release.Namespace }}
   pathPrefixes:
   - /elemental/


### PR DESCRIPTION
This has to be a known value that we can watch for in the operator, this
doesnt require to be unique per deployment as several processes can
watch the same secret

Signed-off-by: Itxaka <igarcia@suse.com>