### PR TITLE
drop unused labels on bootstrap

### DIFF
--- a/pkg/controllers/machineinventoryselector/bootstrap.go
+++ b/pkg/controllers/machineinventoryselector/bootstrap.go
@@ -164,15 +164,6 @@ func (h *handler) getBootstrapPlan(selector *v1beta1.MachineInventorySelector, i
 			},
 			{
 				CommonInstruction: applyinator.CommonInstruction{
-					Command: "bash",
-					Args: []string{
-						"-c",
-						"elemental-register --label \"elemental.cattle.io/ExternalIP=$(hostname -I | awk '{print $1}')\" --label \"elemental.cattle.io/InternalIP=$(hostname -I | awk '{print $2}')\"",
-					},
-				},
-			},
-			{
-				CommonInstruction: applyinator.CommonInstruction{
 					Command: "/var/lib/rancher/bootstrap.sh",
 					// Ensure local plans will be enabled, this is required to ensure the local
 					// plan stopping elemental-system-agent is executed


### PR DESCRIPTION
we are setting some custom labels on bootstrap but they are not used
anywhere.

Drop them unless we have a need to set some specific labels on node
bootstrap

Signed-off-by: Itxaka <igarcia@suse.com>