### PR TITLE
Add extra labels with smbios data

### DIFF
--- a/pkg/server/register_test.go
+++ b/pkg/server/register_test.go
@@ -93,7 +93,7 @@ func TestBuildName(t *testing.T) {
 	}
 
 	for _, testCase := range testCase {
-		assert.Equal(t, testCase.Output, buildName(data, testCase.Format))
+		assert.Equal(t, testCase.Output, buildStringFromSmbiosData(data, testCase.Format))
 	}
 }
 


### PR DESCRIPTION
Now that we get the smbios data properly, we can add extra labels to the
inventory based on that smbios data.

This could be helpful to identify groups of machines in big deployments
and adds extra info to the inventory so we can search using selectors
via kubectl.

Signed-off-by: Itxaka <igarcia@suse.com>