### PR TITLE
Configure custom smbios data

### DIFF
--- a/Examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
+++ b/Examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
@@ -20,3 +20,7 @@ spec:
         iso: https://something.example.com
   machineInventoryLabels:
     clusterName: test
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/Makefile
+++ b/Makefile
@@ -107,3 +107,10 @@ setup-full-cluster: build-docker-operator chart setup-kind
 kind-e2e-tests: build-docker-operator chart setup-kind
 	kind load docker-image --name $(CLUSTER_NAME) ${REPO}:${TAG}
 	CHART=$(CHART) $(MAKE) e2e-tests
+
+# This builds the docker image, generates the chart, loads the image into the kind cluster and upgrades the chart to latest
+# useful to test changes into the operator with a running system, without clearing the operator namespace
+# thus losing any registration/inventories/os CRDs already created
+reload-operator: build-docker-operator chart
+	kind load docker-image --name $(CLUSTER_NAME) ${REPO}:${TAG}
+	helm upgrade -n cattle-elemental-system elemental-operator $(CHART)

--- a/pkg/generated/clientset/versioned/fake/register.go
+++ b/pkg/generated/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/generated/clientset/versioned/scheme/register.go
+++ b/pkg/generated/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/server/register_test.go
+++ b/pkg/server/register_test.go
@@ -40,15 +40,15 @@ func TestBuildName(t *testing.T) {
 	}{
 		{
 			Format: "${level1B}",
-			Output: "level1bvalue",
+			Output: "level1BValue",
 		},
 		{
 			Format: "${level1B",
-			Output: "m-level1b",
+			Output: "m-level1B",
 		},
 		{
 			Format: "a${level1B",
-			Output: "a-level1b",
+			Output: "a-level1B",
 		},
 		{
 			Format: "${}",
@@ -80,15 +80,15 @@ func TestBuildName(t *testing.T) {
 		},
 		{
 			Format: "a${level1A/level2A}c",
-			Output: "alevel2avaluec",
+			Output: "alevel2AValuec",
 		},
 		{
 			Format: "a${level1A/level2B/level3A}c",
-			Output: "alevel3avaluec",
+			Output: "alevel3AValuec",
 		},
 		{
 			Format: "a${level1A/level2B/level3A}c${level1B}",
-			Output: "alevel3avalueclevel1bvalue",
+			Output: "alevel3AValueclevel1BValue",
 		},
 	}
 


### PR DESCRIPTION
This allows to set key/values on the
registration.MachineInventoryLabels that will get parsed into
labels with the help of the smbios data, allowing to set whatever labels
you want to generate via the registration directly

Also fix a bit the sanitation methods to allow data to have dashes and
be uppercase

Sets a specific regex for the machineName as that has more limitations
that labels (no lower dashes, no uppercase)


Signed-off-by: Itxaka <igarcia@suse.com>