### PR TITLE
register/operator: drop MachineInventory labels passed from the client

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/mudler/yip/pkg/schema"
@@ -54,7 +53,6 @@ const (
 
 func main() {
 	var cfg config.Config
-	var labels []string
 	var debug bool
 
 	cmd := &cobra.Command{
@@ -99,17 +97,6 @@ func main() {
 				logrus.Fatal("failed to parse configuration: ", err)
 			}
 
-			if cfg.Elemental.Registration.Labels == nil {
-				cfg.Elemental.Registration.Labels = map[string]string{}
-			}
-
-			for _, label := range labels {
-				parts := strings.Split(label, "=")
-				if len(parts) == 2 {
-					cfg.Elemental.Registration.Labels[parts[0]] = parts[1]
-				}
-			}
-
 			logrus.Debugf("input config:\n%s", litter.Sdump(cfg))
 
 			run(cfg)
@@ -123,7 +110,6 @@ func main() {
 	cmd.Flags().Int64Var(&cfg.Elemental.Registration.EmulatedTPMSeed, "emulated-tpm-seed", 1, "Seed for /dev/tpm emulation")
 	cmd.Flags().BoolVar(&cfg.Elemental.Registration.NoSMBIOS, "no-smbios", false, "Disable the use of dmidecode to get SMBIOS")
 	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug logging")
-	cmd.Flags().StringArrayVar(&labels, "label", nil, "")
 
 	if err := cmd.Execute(); err != nil {
 		logrus.Fatalln(err)
@@ -156,7 +142,7 @@ func run(config config.Config) {
 	}
 
 	for {
-		data, err = register.Register(registration.URL, caCert, !registration.NoSMBIOS, registration.EmulateTPM, registration.EmulatedTPMSeed, registration.Labels)
+		data, err = register.Register(registration.URL, caCert, !registration.NoSMBIOS, registration.EmulateTPM, registration.EmulatedTPMSeed)
 		if err != nil {
 			logrus.Error("failed to register machine inventory: ", err)
 			time.Sleep(time.Second * 5)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,12 +46,11 @@ func (in *Install) DeepCopyInto(out *Install) {
 }
 
 type Registration struct {
-	URL             string            `json:"url,omitempty" yaml:"url,omitempty" mapstructure:"url"`
-	CACert          string            `json:"ca-cert,omitempty" yaml:"ca-cert,omitempty" mapstructure:"ca-cert"`
-	EmulateTPM      bool              `json:"emulate-tpm,omitempty" yaml:"emulate-tpm,omitempty" mapstructure:"emulate-tpm"`
-	EmulatedTPMSeed int64             `json:"emulated-tpm-seed,omitempty" yaml:"emulated-tpm-seed,omitempty" mapstructure:"emulated-tpm-seed"`
-	NoSMBIOS        bool              `json:"no-smbios,omitempty" yaml:"no-smbios,omitempty" mapstructure:"no-smbios"`
-	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty" mapstructure:"labels"`
+	URL             string `json:"url,omitempty" yaml:"url,omitempty" mapstructure:"url"`
+	CACert          string `json:"ca-cert,omitempty" yaml:"ca-cert,omitempty" mapstructure:"ca-cert"`
+	EmulateTPM      bool   `json:"emulate-tpm,omitempty" yaml:"emulate-tpm,omitempty" mapstructure:"emulate-tpm"`
+	EmulatedTPMSeed int64  `json:"emulated-tpm-seed,omitempty" yaml:"emulated-tpm-seed,omitempty" mapstructure:"emulated-tpm-seed"`
+	NoSMBIOS        bool   `json:"no-smbios,omitempty" yaml:"no-smbios,omitempty" mapstructure:"no-smbios"`
 }
 
 type SystemAgent struct {

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -33,7 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulatedSeed int64, labels map[string]string) ([]byte, error) {
+func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulatedSeed int64) ([]byte, error) {
 
 	dialer := websocket.DefaultDialer
 
@@ -95,7 +95,7 @@ func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulated
 	}
 	logrus.Info("TPM attestation successful")
 
-	err = sendData(conn, smbios, labels)
+	err = sendData(conn, smbios)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func Register(url string, caCert []byte, smbios bool, emulatedTPM bool, emulated
 	return ioutil.ReadAll(r)
 }
 
-func sendData(conn *websocket.Conn, smbios bool, labels map[string]string) error {
+func sendData(conn *websocket.Conn, smbios bool) error {
 	if smbios {
 		logrus.Debug("send SMBIOS data")
 		data, err := dmidecode.Decode()
@@ -122,14 +122,6 @@ func sendData(conn *websocket.Conn, smbios bool, labels map[string]string) error
 		if err != nil {
 			logrus.Debugf("SMBIOS data:\n%s", litter.Sdump(data))
 			return fmt.Errorf("sending SMBIOS data: %w", err)
-		}
-	}
-	if len(labels) > 0 {
-		logrus.Debug("send labels")
-		err := SendJSONData(conn, MsgLabels, labels)
-		if err != nil {
-			logrus.Debugf("Labels:\n%s", litter.Sdump(labels))
-			return fmt.Errorf("sending labels: %w", err)
 		}
 	}
 	return nil

--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -132,7 +132,6 @@ func (i *InventoryServer) unauthenticatedResponse(machineRegistration *elm.Machi
 				EmulateTPM:      mRRegistration.EmulateTPM,
 				EmulatedTPMSeed: mRRegistration.EmulatedTPMSeed,
 				NoSMBIOS:        mRRegistration.NoSMBIOS,
-				Labels:          mRRegistration.Labels,
 			},
 		},
 	})
@@ -319,7 +318,6 @@ func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elm.Machine
 			if err := mergeInventoryLabels(inventory, data); err != nil {
 				return msgType, err
 			}
-			updated = true
 		case register.MsgGet:
 			inventory, err = i.commitMachineInventory(inventory, updated)
 			if err != nil {
@@ -347,12 +345,9 @@ func mergeInventoryLabels(inventory *elm.MachineInventory, data []byte) error {
 		return fmt.Errorf("cannot extract inventory labels: %w", err)
 	}
 	logrus.Debugf("received labels: %v", labels)
+	logrus.Warn("received labels from registering client: no more supported, skipping")
 	if inventory.Labels == nil {
-		inventory.Labels = labels
-	} else {
-		for k, v := range labels {
-			inventory.Labels[k] = v
-		}
+		inventory.Labels = map[string]string{}
 	}
 	return nil
 }

--- a/pkg/server/register_test.go
+++ b/pkg/server/register_test.go
@@ -160,7 +160,7 @@ func TestMergeInventoryLabels(t *testing.T) {
 			[]byte(`{"key2":"val2"}`),
 			map[string]string{"key1": "val1"},
 			false,
-			map[string]string{"key1": "val1", "key2": "val2"},
+			map[string]string{"key1": "val1"},
 		},
 		{
 			[]byte(`{"key2":2}`),
@@ -172,7 +172,7 @@ func TestMergeInventoryLabels(t *testing.T) {
 			[]byte(`{"key2":"val2", "key3":"val3"}`),
 			map[string]string{"key1": "val1", "key3": "previous_val", "key4": "val4"},
 			false,
-			map[string]string{"key1": "val1", "key2": "val2", "key3": "val3"},
+			map[string]string{"key1": "val1", "key3": "previous_val"},
 		},
 		{
 			[]byte{},
@@ -184,7 +184,7 @@ func TestMergeInventoryLabels(t *testing.T) {
 			[]byte(`{"key2":"val2"}`),
 			nil,
 			false,
-			map[string]string{"key2": "val2"},
+			map[string]string{},
 		},
 	}
 


### PR DESCRIPTION
The right way to set labels for the MachineInventory objs is to set them in the MachineRegistration:spec:machineInventoryLabels, which will be processed by the operator. Drop MachineRegistration spec:config:elemental:registration:labels.

Fixes #161