### PR TITLE
Add elemental GlobalRole for Rancher UI

### DIFF
--- a/chart/templates/globalrole.yaml
+++ b/chart/templates/globalrole.yaml
@@ -1,0 +1,16 @@
+apiVersion: management.cattle.io/v3
+builtin: false
+description: "Elemental Administrator Role"
+displayName: Elemental Administrator
+kind: GlobalRole
+metadata:
+  labels:
+    cattle.io/creator: norman
+  name: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - elemental.cattle.io
+  resources:
+  - '*'
+  verbs:
+  - '*'


### PR DESCRIPTION
During elemental-operator helm installation, it has to be also added Elemnetal Administator GlobalRole for Rancher UI users.

Fixes https://github.com/rancher/elemental/issues/332

Signed-off-by: Michal Jura <mjura@suse.com>