### PR TITLE
Disable CGO under arm for register binaries

### DIFF
--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -19,6 +19,11 @@ jobs:
           fetch-depth: 0
       - name: cosign-installer
         uses: sigstore/cosign-installer@v2.5.1
+      - name: Install the bom command
+        shell: bash
+        run: |
+          curl -L  https://github.com/kubernetes-sigs/bom/releases/download/v0.3.0/bom-linux-amd64.tar.gz | tar xvz
+          sudo mv ./bom /usr/bin/bom
       - name: Export tag
         id: export_tag
         run: |
@@ -82,6 +87,19 @@ jobs:
             TAG=${{ steps.export_tag.outputs.operator_tag }}
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
             COMMIT=${{ github.sha }}
+      - name: Create SBOM file
+        shell: bash
+        run: |
+          bom generate -o elemental-operator.spdx .
+          bom generate -o elemental-register.spdx .
+      - name: Attach SBOM file in the container image
+        shell: bash
+        run: |
+          set -e
+          cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:${{ steps.export_tag.outputs.operator_tag }}-${GITHUB_SHA::7}"
+          cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:latest"
+          cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:${{ steps.export_tag.outputs.operator_tag }}-${GITHUB_SHA::7}"
+          cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:latest"
       - name: Sign images
         env:
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -19,6 +19,11 @@ jobs:
           fetch-depth: 0
       - name: cosign-installer
         uses: sigstore/cosign-installer@v2.5.1
+      - name: Install the bom command
+        shell: bash
+        run: |
+          curl -L  https://github.com/kubernetes-sigs/bom/releases/download/v0.3.0/bom-linux-amd64.tar.gz | tar xvz
+          sudo mv ./bom /usr/bin/bom
       - name: Export tag
         id: export_tag
         run: |
@@ -80,6 +85,19 @@ jobs:
             TAG=${{ steps.export_tag.outputs.operator_tag }}
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
             COMMIT=${{ github.sha }}
+      - name: Create SBOM file
+        shell: bash
+        run: |
+          bom generate -o elemental-operator.spdx .
+          bom generate -o elemental-register.spdx .
+      - name: Attach SBOM file in the container image
+        shell: bash
+        run: |
+          set -e
+          cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:${{ steps.export_tag.outputs.operator_tag }}-${GITHUB_SHA::7}"
+          cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:latest"
+          cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:${{ steps.export_tag.outputs.operator_tag }}-${GITHUB_SHA::7}"
+          cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:latest"
       - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/gorelease.yaml
+++ b/.github/workflows/gorelease.yaml
@@ -17,6 +17,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
+      - name: Install the bom command
+        shell: bash
+        run: |
+          curl -L  https://github.com/kubernetes-sigs/bom/releases/download/v0.3.0/bom-linux-amd64.tar.gz | tar xvz
+          sudo mv ./bom /usr/bin/bom
       - uses: actions/cache@v2
         with:
           path: |
@@ -32,3 +37,25 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create SBOM file
+        shell: bash
+        run: |
+          mkdir signatures
+          bom generate -o /signatures/elemental-operator.spdx .
+          bom generate -o /signatures/elemental-register.spdx .
+      - name: Sign BOM file
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          cosign sign-blob --output-certificate signatures/elemental-operator.spdx.cert \
+          --output-signature signatures/elemental-operator.spdx.sig \
+          signatures/elemental-operator.spdx
+          cosign sign-blob --output-certificate signatures/elemental-register.spdx.cert \
+          --output-signature signatures/elemental-register.spdx.sig \
+          signatures/elemental-register.spdx
+      - name: Release sbom
+        uses: fnkr/github-action-ghr@v1
+        env:
+          GHR_PATH: signatures/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,21 @@ builds:
     goarm:
       - 6
       - 7
+    overrides: # Disable CGO on arm platforms, means that we don't support emulated TPM under arm
+      - goarch: arm
+        goos: linux
+        goarm: 6
+        env:
+          - CGO_ENABLED=0
+      - goarch: arm
+        goos: linux
+        goarm: 7
+        env:
+          - CGO_ENABLED=0
+      - goarch: arm64
+        goos: linux
+        env:
+          - CGO_ENABLED=0
   - main: ./cmd/support
     binary: elemental-support
     id: elemental-support


### PR DESCRIPTION
Currently we cant cross compile it to support emulated TPM under arm
platforms so our release pipeline is broken

Fixes https://github.com/rancher/elemental/issues/307
Fixes https://github.com/rancher/elemental-operator/issues/192

Signed-off-by: Itxaka <igarcia@suse.com>