### PR TITLE
release: enhance release pipeline

### DIFF
--- a/.github/workflows/gorelease.yaml
+++ b/.github/workflows/gorelease.yaml
@@ -17,11 +17,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
-      - name: Install the bom command
-        shell: bash
-        run: |
-          curl -L  https://github.com/kubernetes-sigs/bom/releases/download/v0.3.0/bom-linux-amd64.tar.gz | tar xvz
-          sudo mv ./bom /usr/bin/bom
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v2.5.1
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0.12.0
       - uses: actions/cache@v2
         with:
           path: |
@@ -37,25 +36,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create SBOM file
-        shell: bash
-        run: |
-          mkdir signatures
-          bom generate -o /signatures/elemental-operator.spdx .
-          bom generate -o /signatures/elemental-register.spdx .
-      - name: Sign BOM file
-        env:
           COSIGN_EXPERIMENTAL: 1
-        run: |
-          cosign sign-blob --output-certificate signatures/elemental-operator.spdx.cert \
-          --output-signature signatures/elemental-operator.spdx.sig \
-          signatures/elemental-operator.spdx
-          cosign sign-blob --output-certificate signatures/elemental-register.spdx.cert \
-          --output-signature signatures/elemental-register.spdx.sig \
-          signatures/elemental-register.spdx
-      - name: Release sbom
-        uses: fnkr/github-action-ghr@v1
-        env:
-          GHR_PATH: signatures/
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,19 +76,22 @@ source:
   enabled: true
   name_template: '{{ .ProjectName }}-{{ .Tag }}-source'
 archives:
-  # Default template uses underscores instead of -
-  - name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+  - format: binary  # This disables creating an archive and leaves the binaries only in the release
 checksum:
   name_template: '{{ .ProjectName }}-{{ .Tag }}-checksums.txt'
 snapshot:
   name_template: "{{ .Tag }}-next"
+sboms:
+  - artifacts: binary
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args: ["sign-blob", "--oidc-issuer=https://token.actions.githubusercontent.com", "--output-certificate=${certificate}", "--output-signature=${signature}", "${artifact}"]
+    artifacts: all
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
       - '^docs:'


### PR DESCRIPTION
 - publish only binaries instead of a tar.gz of the binaries bundle
 - create SBOM as part of the gorelease pipeline
 - use github changelog for the release
 - sign ALL the things. Binaries, checksum, and even the SBOM
 - release also the cert+sig of the generated artifacts

Signed-off-by: Itxaka <igarcia@suse.com>