### PR TITLE
Audit and update elemental-operator RBAC ClusterRole

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -3,93 +3,36 @@ kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}
 rules:
-- apiGroups:
-    - management.cattle.io
-  resources:
-    - 'settings'
-  verbs:
-    - 'get'
-    - 'watch'
-    - 'list'
-- apiGroups:
-  - ""
-  resources:
-  - 'events'
-  verbs:
-  - 'patch'
-  - 'create'
-- apiGroups:
-  - ""
-  resources:
-  - 'secrets'
-  verbs:
-  - 'get'
-  - 'watch'
-  - 'list'
-  - 'create'
-  - 'update'
-  - 'patch'
-  - 'delete'
-- apiGroups:
-  - ""
-  resources:
-  - 'pods'
-  - 'serviceaccounts'
-  verbs:
-  - 'get'
-  - 'create'
-  - 'delete'
-  - 'list'
-  - 'watch'
-- apiGroups:
-    - "rbac.authorization.k8s.io"
-  resources:
-    - 'rolebindings'
-    - 'roles'
-  verbs:
-    - 'get'
-    - 'create'
-    - 'delete'
-    - 'watch'
-- apiGroups:
-  - ""
-  resources:
-  - 'pods/log'
-  verbs:
-  - 'get'
-- apiGroups:
-  - elemental.cattle.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - fleet.cattle.io
-  resources:
-  - 'bundles'
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - '*'
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - 'list'
-  - 'get'
-- apiGroups:
-    - cluster.x-k8s.io
-  resources:
-    - machines
-  verbs:
-    - 'list'
-    - 'get'
-    - 'watch'
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "serviceaccounts"]
+    verbs: ["get", "watch", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["*"]
+  - apiGroups: ["cluster.x-k8s.io"]
+    resources: ["machines"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["elemental.cattle.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["fleet.cattle.io"]
+    resources: ["bundles"]
+    verbs: ["*"]
+  - apiGroups: ["management.cattle.io"]
+    resources: ["settings"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings", "roles"]
+    verbs: ["get", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
It seems that elemental-operator RBAC ClusterRole was too wide. This change is simplifying it and removing unneeded privileges.

Fixes #https://github.com/rancher/elemental-operator/issues/186

Signed-off-by: Michal Jura <mjura@suse.com>