### PR TITLE
Kubebuilder: Run new code and generate RBAC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY go.mod go.sum /src/
 RUN go mod download
 COPY cmd/operator/main.go /src/
+COPY api /src/api
 COPY pkg /src/pkg
 COPY cmd/operator /src/cmd/operator
 COPY cmd/register /src/cmd/register

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ build-docker-push-register: build-docker-register
 	docker push ${REPO_REGISTER}:${TAG}
 
 .PHONY: chart
-chart: generate build-manifests
+chart:
 	mkdir -p  $(ROOT_DIR)/build
 	cp -rf $(ROOT_DIR)/chart $(ROOT_DIR)/build/chart
 	sed -i -e 's/tag:.*/tag: '${TAG}'/' $(ROOT_DIR)/build/chart/values.yaml

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,6 @@ build: operator register support
 operator:
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o $(BUILD_DIR)/elemental-operator $(ROOT_DIR)/cmd/operator
 
-operator-kubebuilder:
-	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o $(BUILD_DIR)/elemental-operator-kubebuilder $(ROOT_DIR)/cmd/operator-kubebuilder
-
 .PHONY: register
 register:
 	CGO_ENABLED=1 go build -ldflags '$(LDFLAGS)' -o $(BUILD_DIR)/elemental-register $(ROOT_DIR)/cmd/register
@@ -108,7 +105,7 @@ build-docker-push-register: build-docker-register
 	docker push ${REPO_REGISTER}:${TAG}
 
 .PHONY: chart
-chart:
+chart: generate build-manifests
 	mkdir -p  $(ROOT_DIR)/build
 	cp -rf $(ROOT_DIR)/chart $(ROOT_DIR)/build/chart
 	sed -i -e 's/tag:.*/tag: '${TAG}'/' $(ROOT_DIR)/build/chart/values.yaml
@@ -165,10 +162,11 @@ generate: $(CONTROLLER_GEN) ## Generate code
 generate-manifests: $(CONTROLLER_GEN) ## Generate manifests for the operator e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
+		paths=./cmd/operator/operator-kubebuilder/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases \
-		output:rbac:dir=./config/rbac \
+		output:rbac:dir=./config/rbac/bases \
 		output:webhook:dir=./config/webhook \
 		webhook
 
@@ -181,5 +179,9 @@ generate-go: $(CONTROLLER_GEN) ## Runs Go related generate targets for the opera
 build-crds: $(KUSTOMIZE)
 	$(KUSTOMIZE) build config/crd > chart/templates/crds.yaml
 
+build-rbac: $(KUSTOMIZE)
+	$(KUSTOMIZE) build config/rbac > chart/templates/cluster_role.yaml
+
 build-manifests: $(KUSTOMIZE)
 	$(MAKE) build-crds
+	$(MAKE) build-rbac

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -44,6 +44,20 @@ spec:
         - --default-registry
         - {{ .Values.global.cattle.systemDefaultRegistry | quote }}
         {{- end }}
+      - env:
+        - name: NO_PROXY
+          value: {{ .Values.noProxy }}
+        {{- if .Values.proxy }}
+        - name: HTTP_PROXY
+          value: {{ .Values.proxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.proxy }}
+        {{- end }}
+        name: {{ .Release.Name }}-kubebuilder
+        imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        args:
+        - ctrl-runtime-operator
       serviceAccountName: {{ .Release.Name }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	displayCmd "github.com/rancher/elemental-operator/cmd/operator/display"
 	operatorCmd "github.com/rancher/elemental-operator/cmd/operator/operator"
+	kubebuilderCmd "github.com/rancher/elemental-operator/cmd/operator/operator-kubebuilder"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,7 @@ func main() {
 
 	cmd.AddCommand(
 		operatorCmd.NewOperatorCommand(),
+		kubebuilderCmd.NewOperatorCtrlRuntimeCommand(),
 		displayCmd.NewDisplayCommand())
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/operator/operator-kubebuilder/root.go
+++ b/cmd/operator/operator-kubebuilder/root.go
@@ -1,0 +1,192 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ctrlruntimeoperator
+
+import (
+	"net/http"
+	"os"
+	"time"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/version"
+	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+// IMPORTANT: The RBAC permissions below should be reviewed after old code is deprecated.
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=patch;create
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;create;delete;list;watch
+// +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
+// +kubebuilder:rbac:groups="fleet.cattle.io",resources=bundles,verbs=*
+// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=*
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+type rootConfig struct {
+	enableLeaderElection        bool
+	profilerAddress             string
+	metricsBindAddr             string
+	syncPeriod                  time.Duration
+	leaderElectionLeaseDuration time.Duration
+	leaderElectionRenewDeadline time.Duration
+	leaderElectionRetryPeriod   time.Duration
+	webhookPort                 int
+	webhookCertDir              string
+	healthAddr                  string
+}
+
+func init() {
+	utilruntime.Must(elementalv1.AddToScheme(scheme))
+	utilruntime.Must(managementv3.AddToScheme(scheme))
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(clusterv1.AddToScheme(scheme))
+}
+
+func NewOperatorCtrlRuntimeCommand() *cobra.Command {
+	var config rootConfig
+
+	cmd := &cobra.Command{
+		Use:   "operator-kubebuilder",
+		Short: "Run the Kubernetes operator using kubebuilder.",
+		Run: func(_ *cobra.Command, _ []string) {
+			logrus.Infof("Operator version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
+			operatorRun(&config)
+		},
+	}
+
+	viper.AutomaticEnv()
+
+	cmd.PersistentFlags().StringVar(&config.profilerAddress, "profiler-address", "",
+		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
+	_ = viper.BindPFlag("profiler-address", cmd.PersistentFlags().Lookup("profiler-address"))
+
+	cmd.PersistentFlags().StringVar(&config.metricsBindAddr, "metrics-bind-addr", ":8080",
+		"The address the metric endpoint binds to.")
+	_ = viper.BindPFlag("profiler-address", cmd.PersistentFlags().Lookup("profiler-address"))
+
+	cmd.PersistentFlags().DurationVar(&config.syncPeriod, "sync-period", 10*time.Minute,
+		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
+	_ = viper.BindPFlag("sync-interval", cmd.PersistentFlags().Lookup("sync-interval"))
+
+	cmd.PersistentFlags().DurationVar(&config.leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
+	_ = viper.BindPFlag("sync-interval", cmd.PersistentFlags().Lookup("sync-interval"))
+
+	cmd.PersistentFlags().DurationVar(&config.leaderElectionRenewDeadline, "leader-elect-renew-deadlined", 10*time.Second,
+		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
+	_ = viper.BindPFlag("sync-interval", cmd.PersistentFlags().Lookup("sync-interval"))
+
+	cmd.PersistentFlags().DurationVar(&config.leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
+	_ = viper.BindPFlag("sync-interval", cmd.PersistentFlags().Lookup("sync-interval"))
+
+	cmd.PersistentFlags().BoolVar(&config.enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	_ = viper.BindPFlag("leader-elect", cmd.PersistentFlags().Lookup("leader-elect"))
+
+	cmd.PersistentFlags().IntVar(&config.webhookPort, "webhook-port", 9443,
+		"Webhook Server port.")
+	_ = viper.BindPFlag("leader-elect", cmd.PersistentFlags().Lookup("leader-elect"))
+
+	cmd.PersistentFlags().StringVar(&config.webhookCertDir, "webhook-cert-dir", ":8080",
+		"Webhook cert dir, only used when webhook-port is specified.")
+	_ = viper.BindPFlag("profiler-address", cmd.PersistentFlags().Lookup("profiler-address"))
+
+	cmd.PersistentFlags().StringVar(&config.healthAddr, "health-addr", ":9440",
+		"The address the health endpoint binds to.")
+	_ = viper.BindPFlag("profiler-address", cmd.PersistentFlags().Lookup("profiler-address"))
+
+	return cmd
+}
+
+func operatorRun(config *rootConfig) {
+	ctrl.SetLogger(klogr.New())
+
+	if config.profilerAddress != "" {
+		klog.Infof("Profiler listening for requests at %s", config.profilerAddress)
+		go func() {
+			klog.Info(http.ListenAndServe(config.profilerAddress, nil))
+		}()
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:             scheme,
+		MetricsBindAddress: config.metricsBindAddr,
+		LeaderElection:     config.enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-elemental-operator",
+		LeaseDuration:      &config.leaderElectionLeaseDuration,
+		RenewDeadline:      &config.leaderElectionRenewDeadline,
+		RetryPeriod:        &config.leaderElectionRetryPeriod,
+		SyncPeriod:         &config.syncPeriod,
+		ClientDisableCacheFor: []client.Object{
+			&corev1.ConfigMap{},
+			&corev1.Secret{},
+		},
+		Port:                   config.webhookPort,
+		CertDir:                config.webhookCertDir,
+		HealthProbeBindAddress: config.healthAddr,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Setup the context that's going to be used in controllers and for the manager.
+	ctx := ctrl.SetupSignalHandler()
+
+	setupChecks(mgr)
+	setupReconcilers(mgr)
+
+	// +kubebuilder:scaffold:builder
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func setupChecks(mgr ctrl.Manager) {
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to create ready check")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to create health check")
+		os.Exit(1)
+	}
+}
+
+func setupReconcilers(mgr ctrl.Manager) {
+	// to be implemented
+}

--- a/config/rbac/bases/role.yaml
+++ b/config/rbac/bases/role.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - fleet.cattle.io
+  resources:
+  - bundles
+  verbs:
+  - '*'

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bases/role.yaml
+
+patchesJson6902: ## this is used to patch role name so we can use in helm chart template
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: manager-role
+    path: patches/name_in_role.yaml

--- a/config/rbac/patches/name_in_role.yaml
+++ b/config/rbac/patches/name_in_role.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: "{{ .Release.Name }}"


### PR DESCRIPTION
This PR adds a new command for running kubebuilder-based code together with the old one and adds a new make task for generating RBAC from code.