### PR TITLE
Collect operator logs after running tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -103,3 +103,8 @@ jobs:
           skipClusterCreation: "true"
       - name: e2e tests
         run: make e2e-tests
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-artifacts
+          path: _artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 coverage.out
 .idea/*
+_artifacts/

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -32,6 +32,7 @@ type E2EConfig struct {
 	BridgeIP         string `yaml:"bridgeIP"`
 	OperatorReplicas string `yaml:"operatorReplicas"`
 	NoSetup          bool   `yaml:"noSetup"`
+	ArtifactsDir     string `yaml:"artifactsDir"`
 
 	NginxVersion string `yaml:"nginxVersion"`
 	NginxURL     string `yaml:"nginxURL"`
@@ -94,6 +95,10 @@ func ReadE2EConfig(configPath string) (*E2EConfig, error) { //nolint:gocyclo
 
 	if noSetup := os.Getenv("NO_SETUP"); noSetup != "" {
 		config.NoSetup = true
+	}
+
+	if artifactsDir := os.Getenv("ARTIFACTS_DIR"); artifactsDir != "" {
+		config.ArtifactsDir = artifactsDir
 	}
 
 	if nginxVersion := os.Getenv("NGINX_VERSION"); nginxVersion != "" {

--- a/tests/e2e/config/config.yaml
+++ b/tests/e2e/config/config.yaml
@@ -4,6 +4,7 @@ magicDNS: sslip.io
 bridgeIP: 172.17.0.1
 operatorReplicas: 1
 noSetup: false
+artifactsDir: ../../_artifacts
 
 nginxVersion: controller-v1.4.0
 nginxURL: https://raw.githubusercontent.com/kubernetes/ingress-nginx/${NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml


### PR DESCRIPTION
Collect operator logs after running tests. It's possible to download them from the job summary page.