### PR TITLE
operator: ensure MachineRegistration has config:elemental:install:device

### DIFF
--- a/pkg/apis/elemental.cattle.io/v1beta1/registration.go
+++ b/pkg/apis/elemental.cattle.io/v1beta1/registration.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	MachineRegistrationReadyReason = "MachineRegistrationReady"
+	MachineRegistrationReadyReason            = "MachineRegistrationReady"
+	MachineRegistrationMissTargetDeviceReason = "NoTargetDeviceProvided"
 )
 
 // +genclient

--- a/pkg/controllers/registration/registration.go
+++ b/pkg/controllers/registration/registration.go
@@ -65,8 +65,10 @@ func (h *handler) OnChange(obj *elm.MachineRegistration, status elm.MachineRegis
 
 	if obj.Spec.Config == nil || obj.Spec.Config.Elemental.Install.Device == "" {
 		// Let's deal with the error here and avoid the worker to requeue the resource
-		utilruntime.HandleError(fmt.Errorf("MachineRegistration '%s' misses the target device (spec:config:elemental:install:device)",
+		utilruntime.HandleError(fmt.Errorf("MachineRegistration '%s' misses the target device config (spec:config:elemental:install:device)",
 			obj.Namespace+"/"+obj.Name))
+		elm.ReadyCondition.SetError(&status, elm.MachineRegistrationMissTargetDeviceReason,
+			fmt.Errorf("'spec:config:elemental:install:device' is required"))
 		return status, nil
 	}
 


### PR DESCRIPTION
the only real mandatory config we need is the target device (which will be later cause host installation failure if not present): check its presence at resource creation/change.
Note that an empty spec:config causes also a panic on the registration  yaml retrieval via the HTTP GET to the registration URL: this because the config structure was not allocated (see #202).

Fixes #202
