### PR TITLE
Label secrets managed by elemental-operator

### DIFF
--- a/pkg/apis/elemental.cattle.io/v1beta1/machine.go
+++ b/pkg/apis/elemental.cattle.io/v1beta1/machine.go
@@ -34,6 +34,8 @@ var (
 	PlanSuccefullyAppliedReason     = "PlanSuccefullyApplied"
 	PlanFailedToBeAppliedReason     = "PlanFailedToBeApplied"
 
+	ManagedSecretLabel = "elemental.cattle.io/managed"
+
 	PlanSecretType corev1.SecretType = "elemental.cattle.io/plan"
 )
 

--- a/pkg/controllers/machineinventory/machineinventory.go
+++ b/pkg/controllers/machineinventory/machineinventory.go
@@ -107,6 +107,9 @@ func (h *handler) initializeHandler(obj *v1beta1.MachineInventory, status v1beta
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: obj.Namespace,
 			Name:      obj.Name,
+			Labels: map[string]string{
+				v1beta1.ManagedSecretLabel: "true",
+			},
 		},
 		Type:       v1beta1.PlanSecretType,
 		StringData: map[string]string{"plan": "{}"},

--- a/pkg/controllers/managedos/template.go
+++ b/pkg/controllers/managedos/template.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
 	elm "github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/clients"
 	fleet "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
@@ -207,6 +208,9 @@ func (h *handler) objects(mos *elm.ManagedOSImage) ([]runtime.Object, error) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "os-upgrader-data",
 				Namespace: clients.SystemNamespace,
+				Labels: map[string]string{
+					v1beta1.ManagedSecretLabel: "true",
+				},
 			},
 			Data: map[string][]byte{
 				"cloud-config": cloudConfig,

--- a/pkg/controllers/registration/registration.go
+++ b/pkg/controllers/registration/registration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
 	elm "github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/clients"
 	elmcontrollers "github.com/rancher/elemental-operator/pkg/generated/controllers/elemental.cattle.io/v1beta1"
@@ -98,6 +99,9 @@ func (h *handler) OnChange(obj *elm.MachineRegistration, status elm.MachineRegis
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: obj.Namespace,
+			Labels: map[string]string{
+				v1beta1.ManagedSecretLabel: "true",
+			},
 			Annotations: map[string]string{
 				"kubernetes.io/service-account.name": obj.Name,
 			},


### PR DESCRIPTION
Mark secrets created and managed by elemental-operator. It is needed for rancher-backup opeator to select them for backup.

Fixes https://github.com/rancher/elemental/issues/396

Signed-off-by: Michal Jura <mjura@suse.com>