### PR TITLE
tests: use latest url for rancher charts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.0.11
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
       - uses: actions/cache@v2

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install yq
@@ -41,7 +41,7 @@ jobs:
         id: chart
         run: |
           CHART=$(find . -type f  -name "elemental-operator*.tgz" -print)
-          echo "::set-output name=chart_name::$CHART"
+          echo "chart_name=$CHART" >> $GITHUB_OUTPUT
       - name: Test chart values
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |

--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -14,11 +14,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: cosign-installer
-        uses: sigstore/cosign-installer@v2.5.1
+        uses: sigstore/cosign-installer@v2.8.0
       - name: Install the bom command
         shell: bash
         run: |
@@ -30,11 +30,11 @@ jobs:
           git describe --abbrev=0 --tags
           TAG=`git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"`
           COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
-          echo "::set-output name=operator_tag::$TAG"
-          echo "::set-output name=commit_date::$COMMITDATE"
+          echo "operator_tag=$TAG" >> $GITHUB_OUTPUT
+          echo "commit_date=$COMMITDATE" >> $GITHUB_OUTPUT
       - name: Docker meta for operator master
         id: meta-operator
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4.1.1
         with:
           images: |
             ${{ env.OPERATOR_REPO }}
@@ -43,7 +43,7 @@ jobs:
             type=raw,value=latest
       - name: Docker meta for register master
         id: meta-register
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4.1.1
         with:
           images: |
             ${{ env.REGISTER_REPO }}
@@ -52,15 +52,15 @@ jobs:
             type=raw,value=latest
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Login to Quay
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Build operator image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           tags: ${{ steps.meta-operator.outputs.tags }}
@@ -74,7 +74,7 @@ jobs:
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
             COMMIT=${{ github.sha }}
       - name: Build register image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           tags: ${{ steps.meta-register.outputs.tags }}

--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -14,11 +14,11 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: cosign-installer
-        uses: sigstore/cosign-installer@v2.5.1
+        uses: sigstore/cosign-installer@v2.8.0
       - name: Install the bom command
         shell: bash
         run: |
@@ -30,11 +30,11 @@ jobs:
           git describe --abbrev=0 --tags
           TAG=`git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"`
           COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
-          echo "::set-output name=operator_tag::$TAG"
-          echo "::set-output name=commit_date::$COMMITDATE"
+          echo "operator_tag=$TAG" >> $GITHUB_OUTPUT
+          echo "commit_date=$COMMITDATE" >> $GITHUB_OUTPUT
       - name: Docker meta for operator tag
         id: meta-operator
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4.1.1
         with:
           images: |
             ${{ env.OPERATOR_REPO }}
@@ -42,7 +42,7 @@ jobs:
             type=semver,pattern={{raw}}
       - name: Docker meta for register tag
         id: meta-register
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4.1.1
         with:
           images: |
             ${{ env.REGISTER_REPO }}
@@ -50,15 +50,15 @@ jobs:
             type=semver,pattern={{raw}}
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Login to Quay
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
       - name: Build operator image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           tags: ${{ steps.meta-operator.outputs.tags }}
@@ -72,7 +72,7 @@ jobs:
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
             COMMIT=${{ github.sha }}
       - name: Build register image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           tags: ${{ steps.meta-register.outputs.tags }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -69,6 +69,10 @@ jobs:
         kubernetes: [ "v1.24.6", "v1.23.12"]
         replicas: ["1"]
         rancherVersion : ["2.6.9-rc6"]
+        include:
+          - kubernetes: "v1.22.7"
+            replicas: "1"
+            rancherVersion: "2.6.6"
     runs-on: ubuntu-latest
     needs: push-docker
     name: k8s ${{ matrix.kubernetes }} - Rancher ${{ matrix.rancherVersion }} - ${{ matrix.replicas }} replicas

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,9 +66,9 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        kubernetes: [ "v1.24.6", "v1.23.12"]
+        kubernetes: [ "v1.23.12"]
         replicas: ["1"]
-        rancherVersion : ["2.6.9-rc6"]
+        rancherVersion : ["2.6.9"]
         include:
           - kubernetes: "v1.22.7"
             replicas: "1"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,15 +66,24 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        kubernetes: [ "v1.22.7" ]
-        replicas: ["1", "2"]
+        kubernetes: [ "v1.24.6", "v1.23.12"]
+        replicas: ["1"]
+        rancherVersion : ["2.6.9-rc6", "2.6.8", "2.6.7"]
+        include:
+          - kubernetes: "v1.23.12"
+            replicas: "1"
+            rancherVersion: "2.6.6"  # 2.6.6 doesnt support k8s 1.24
+          - kubernetes: "v1.24.6"
+            replicas: "2"
+            rancherVersion: "2.6.9-rc6"  # Run just one job with latest for 2 replicas
     runs-on: ubuntu-latest
     needs: push-docker
-    name: k8s ${{ matrix.kubernetes }} - ${{ matrix.replicas }} replicas
+    name: k8s ${{ matrix.kubernetes }} - Rancher ${{ matrix.rancherVersion }} - ${{ matrix.replicas }} replicas
     env:
       CHART: ${{ github.workspace }}/build/${{ needs.push-docker.outputs.chart_name }}
       KUBE_VERSION: ${{ matrix.kubernetes }}
       OPERATOR_REPLICAS: ${{ matrix.replicas }}
+      RANCHER_VERSION: ${{ matrix.rancherVersion }}
     steps:
       - uses: actions/checkout@v2
       - name: Download chart

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -108,7 +108,7 @@ jobs:
           make unit-tests-deps
       - uses: engineerd/setup-kind@v0.5.0
         with:
-          version: "v0.11.1"
+          version: "v0.16.0"
           skipClusterCreation: "true"
       - name: e2e tests
         run: make e2e-tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -68,14 +68,7 @@ jobs:
       matrix:
         kubernetes: [ "v1.24.6", "v1.23.12"]
         replicas: ["1"]
-        rancherVersion : ["2.6.9-rc6", "2.6.8", "2.6.7"]
-        include:
-          - kubernetes: "v1.23.12"
-            replicas: "1"
-            rancherVersion: "2.6.6"  # 2.6.6 doesnt support k8s 1.24
-          - kubernetes: "v1.24.6"
-            replicas: "2"
-            rancherVersion: "2.6.9-rc6"  # Run just one job with latest for 2 replicas
+        rancherVersion : ["2.6.9-rc6"]
     runs-on: ubuntu-latest
     needs: push-docker
     name: k8s ${{ matrix.kubernetes }} - Rancher ${{ matrix.rancherVersion }} - ${{ matrix.replicas }} replicas
@@ -95,7 +88,7 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.0.11
         with:
           path: |
             ~/go/pkg/mod
@@ -113,7 +106,9 @@ jobs:
       - name: e2e tests
         run: make e2e-tests
       - name: Archive artifacts
+        if: always()
         uses: actions/upload-artifact@v3.1.0
         with:
           name: ci-artifacts
           path: _artifacts
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       chart_name: ${{ steps.chart.outputs.chart_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Export tag
@@ -24,11 +24,11 @@ jobs:
         run: |
           TAG=`git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0"`
           COMMITDATE=`date -d @$(git log -n1 --format="%at") "+%FT%TZ"`
-          echo "::set-output name=operator_tag::$TAG"
-          echo "::set-output name=commit_date::$COMMITDATE"
+          echo "operator_tag=$TAG" >> $GITHUB_OUTPUT
+          echo "commit_date=$COMMITDATE" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4.1.1
         with:
           images: |
             ${{ env.REPO }}
@@ -36,9 +36,9 @@ jobs:
             type=sha,format=short,prefix=${{ steps.export_tag.outputs.operator_tag }}-
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
@@ -57,9 +57,9 @@ jobs:
         id: chart
         run: |
           CHART=$(basename `find . -type f  -name "elemental-operator*.tgz" -print`)
-          echo "::set-output name=chart_name::$CHART"
+          echo "chart_name=$CHART" >> $GITHUB_OUTPUT
       - name: Upload chart
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: chart
           path: build/*.tgz
@@ -85,14 +85,14 @@ jobs:
       OPERATOR_REPLICAS: ${{ matrix.replicas }}
       RANCHER_VERSION: ${{ matrix.rancherVersion }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download chart
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3.0.0
         with:
           name: chart
           path: build
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
       - uses: actions/cache@v2
@@ -113,7 +113,7 @@ jobs:
       - name: e2e tests
         run: make e2e-tests
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: ci-artifacts
           path: _artifacts

--- a/.github/workflows/gorelease.yaml
+++ b/.github/workflows/gorelease.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: sigstore/cosign-installer@v2.8.0
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0.12.0
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.0.11
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/gorelease.yaml
+++ b/.github/workflows/gorelease.yaml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.5.1
+        uses: sigstore/cosign-installer@v2.8.0
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0.12.0
       - uses: actions/cache@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17.x
       - name: Analysis

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,6 @@ jobs:
         with:
           go-version: 1.17.x
       - name: Analysis
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           args: -v

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,9 +11,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.17.x
     - uses: actions/cache@v2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.17.x
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3.0.11
       with:
         path: |
           ~/go/pkg/mod

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REPO_REGISTER?=quay.io/costoolkit/elemental-register-ci
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CHART?=$(shell find $(ROOT_DIR) -type f  -name "elemental-operator*.tgz" -print)
 CHART_VERSION?=$(subst v,,$(GIT_TAG))
-KUBE_VERSION?="v1.22.7"
+KUBE_VERSION?="v1.24.6"
 CLUSTER_NAME?="operator-e2e"
 RAWCOMMITDATE=$(shell git log -n1 --format="%at")
 COMMITDATE?=$(shell date -d @"${RAWCOMMITDATE}" "+%FT%TZ")

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ e2e-tests: chart setup-kind
 	export EXTERNAL_IP=`kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type == "InternalIP")].address}'` && \
 	export BRIDGE_IP="172.18.0.1" && \
 	export CONFIG_PATH=$(E2E_CONF_FILE) && \
-	cd $(ROOT_DIR)/tests && ginkgo -r -v ./e2e
+	cd $(ROOT_DIR)/tests && ginkgo -progress --fail-fast -r -v ./e2e
 
 # Only setups the kind cluster
 setup-kind:

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KUBE_VERSION=${KUBE_VERSION:-v1.22.7}
+KUBE_VERSION=${KUBE_VERSION:-v1.24.6}
 CLUSTER_NAME="${CLUSTER_NAME:-operator-e2e}"
 
 if ! kind get clusters | grep "$CLUSTER_NAME"; then

--- a/tests/e2e/config/config.go
+++ b/tests/e2e/config/config.go
@@ -118,7 +118,7 @@ func ReadE2EConfig(configPath string) (*E2EConfig, error) { //nolint:gocyclo
 	}
 
 	if rancherVersion := os.Getenv("RANCHER_VERSION"); rancherVersion != "" {
-		config.RancherChartURL = rancherVersion
+		config.RancherVersion = rancherVersion
 	}
 
 	if rancherURL := os.Getenv("RANCHER_CHART_URL"); rancherURL != "" {

--- a/tests/e2e/config/config.yaml
+++ b/tests/e2e/config/config.yaml
@@ -9,7 +9,7 @@ artifactsDir: ../../_artifacts
 nginxVersion: controller-v1.4.0
 nginxURL: https://raw.githubusercontent.com/kubernetes/ingress-nginx/${NGINX_VERSION}/deploy/static/provider/kind/deploy.yaml
 
-certManagerVersion: v1.5.3
+certManagerVersion: v1.7.1
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
 rancherVersion: 2.6.6

--- a/tests/e2e/config/config.yaml
+++ b/tests/e2e/config/config.yaml
@@ -13,7 +13,7 @@ certManagerVersion: v1.5.3
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
 rancherVersion: 2.6.6
-rancherChartURL: https://releases.rancher.com/server-charts/stable/rancher-${RANCHER_VERSION}.tgz
+rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz
 
 systemUpgradeControllerVersion: v0.9.1
 systemUpgradeControllerURL: https://github.com/rancher/system-upgrade-controller/releases/download/${SYSTEM_UPGRADE_CONTROLLER_VERSION}/system-upgrade-controller.yaml


### PR DESCRIPTION
Tests latest rancher 2.6.9 + k8s 1.23.X
Adds known test for rancher 2.6.6 + k8s 1.22.X
Updates actions to latests

Signed-off-by: Itxaka <igarcia@suse.com>