### PR TITLE
coverity: make patch status informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,6 @@ coverage:
           - "pkg/"
         target: 75%
         informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
...so, it should not block the merging.