### PR TITLE
tests: Add k8s 1.24 and default to rancher 2.6.9

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,13 +66,9 @@ jobs:
   e2e-tests:
     strategy:
       matrix:
-        kubernetes: [ "v1.23.12"]
+        kubernetes: [ "v1.24.6", "v1.23.12"]
         replicas: ["1"]
         rancherVersion : ["2.6.9"]
-        include:
-          - kubernetes: "v1.22.7"
-            replicas: "1"
-            rancherVersion: "2.6.6"
     runs-on: ubuntu-latest
     needs: push-docker
     name: k8s ${{ matrix.kubernetes }} - Rancher ${{ matrix.rancherVersion }} - ${{ matrix.replicas }} replicas

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -26,4 +26,10 @@ set -e
 kubectl cluster-info --context kind-$CLUSTER_NAME
 echo "Sleep to give times to node to populate with all info"
 kubectl wait --for=condition=Ready node/operator-e2e-control-plane
+# Label the nodes with node-role.kubernetes.io/master as it appears that
+# label is no longer added on >=1.24.X clusters while it was set on <=1.23.X
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint
+# https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24
+# system-upgrade-controller 0.9.1 still uses it to schedule pods
+kubectl label nodes --all node-role.kubernetes.io/master=
 kubectl get nodes -o wide

--- a/tests/e2e/config/config.yaml
+++ b/tests/e2e/config/config.yaml
@@ -12,7 +12,7 @@ nginxURL: https://raw.githubusercontent.com/kubernetes/ingress-nginx/${NGINX_VER
 certManagerVersion: v1.7.1
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.6.6
+rancherVersion: 2.6.9
 rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz
 
 systemUpgradeControllerVersion: v0.9.1


### PR DESCRIPTION
Also drop old 2.6.6 test.

Signed-off-by: Itxaka <igarcia@suse.com>