### PR TITLE
operator: create ServiceAccounts before their Secrets

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -11,7 +11,7 @@ rules:
     verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
   - apiGroups: [""]
     resources: ["pods", "serviceaccounts"]
-    verbs: ["get", "watch", "list", "create", "delete"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]

--- a/pkg/controllers/registration/registration.go
+++ b/pkg/controllers/registration/registration.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
 	elm "github.com/rancher/elemental-operator/pkg/apis/elemental.cattle.io/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/clients"
 	elmcontrollers "github.com/rancher/elemental-operator/pkg/generated/controllers/elemental.cattle.io/v1beta1"
@@ -79,7 +78,7 @@ func (h *handler) OnChange(obj *elm.MachineRegistration, status elm.MachineRegis
 			Name:      obj.Name,
 			Namespace: obj.Namespace,
 			Labels: map[string]string{
-				v1beta1.ManagedSecretLabel: "true",
+				elm.ManagedSecretLabel: "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{{
@@ -103,7 +102,7 @@ func (h *handler) OnChange(obj *elm.MachineRegistration, status elm.MachineRegis
 			Name:      obj.Name,
 			Namespace: obj.Namespace,
 			Labels: map[string]string{
-				v1beta1.ManagedSecretLabel: "true",
+				elm.ManagedSecretLabel: "true",
 			},
 		},
 		Secrets: []corev1.ObjectReference{
@@ -140,7 +139,7 @@ func (h *handler) OnChange(obj *elm.MachineRegistration, status elm.MachineRegis
 			Name:      secretName,
 			Namespace: obj.Namespace,
 			Labels: map[string]string{
-				v1beta1.ManagedSecretLabel: "true",
+				elm.ManagedSecretLabel: "true",
 			},
 			Annotations: map[string]string{
 				"kubernetes.io/service-account.name": obj.Name,
@@ -157,7 +156,7 @@ func (h *handler) OnChange(obj *elm.MachineRegistration, status elm.MachineRegis
 			Name:      obj.Name,
 			Namespace: obj.Namespace,
 			Labels: map[string]string{
-				v1beta1.ManagedSecretLabel: "true",
+				elm.ManagedSecretLabel: "true",
 			},
 		},
 		Subjects: []rbacv1.Subject{{


### PR DESCRIPTION
A Secret referencing a missing ServiceAccount is deleted by the Secret controller.
While we create them one after the other, still the safest path is to create the ServiceAccount first.
Otherwise we may be exposed to a race condition in which:
1. We create the Secret referencing an unexistent ServiceAccount
2. The Secret controller will detect a Secret referencing an unexistent ServiceAccount and will mark it for deletion
3. The ServiceAccount is created with the reference to the Secret
4. The Secret gets removed from the controller: the controller also updates the ServiceAccount removing the linked Secret

So, let's create ServiceAccounts first.
Moreover, let's also update existing ServiceAccounts if we found them without the Secrets: this will fix existing ServiceAccounts (if the associated MachineRegistration is edited so we fire the controller).
And last thing... added more verbose debug logs (which would have allowed to identify the race condition above much more easily).

Fixes #197 