### PR TITLE
Fix docker and gorelease jobs

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install yq
-        uses: mikefarah/yq@v4.25.3
+        uses: mikefarah/yq@v4.28.2
       - name: Build chart for CI
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |

--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -94,9 +94,9 @@ jobs:
         shell: bash
         run: |
           set -e
-          cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:${{ steps.export_tag.outputs.operator_tag }}-${GITHUB_SHA::7}"
+          cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:${{ steps.export_tag.outputs.operator_tag }}"
           cosign attach sbom --sbom elemental-operator.spdx "${{ env.OPERATOR_REPO }}:latest"
-          cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:${{ steps.export_tag.outputs.operator_tag }}-${GITHUB_SHA::7}"
+          cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:${{ steps.export_tag.outputs.operator_tag }}"
           cosign attach sbom --sbom elemental-register.spdx "${{ env.REGISTER_REPO }}:latest"
       - name: Sign image
         env:

--- a/.github/workflows/gorelease.yaml
+++ b/.github/workflows/gorelease.yaml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-release-go-${{ hashFiles('**/go.sum') }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3.2.0
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/gorelease.yaml
+++ b/.github/workflows/gorelease.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
On docker job: sbom job was adding the sha to a tagged release so it failed to find the image
On goreleaser job: job didnt have the proper permissions

fixes #229 

Also bumps some of the actions to fix some deprecations

Signed-off-by: Itxaka <igarcia@suse.com>