### PR TITLE
Kubebuilder: Add "verify" workflow

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,26 @@
+name: Verify
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.x
+    - uses: actions/cache@v3.0.11
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
+    - name: Run make verify
+      run: |
+        make verify

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,25 @@ build-crds: $(KUSTOMIZE)
 build-rbac: $(KUSTOMIZE)
 	$(KUSTOMIZE) build config/rbac > chart/templates/cluster_role.yaml
 
-build-manifests: $(KUSTOMIZE)
+build-manifests: $(KUSTOMIZE) generate
 	$(MAKE) build-crds
 	$(MAKE) build-rbac
+
+ALL_VERIFY_CHECKS = manifests vendor
+
+.PHONY: verify
+verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS))
+
+.PHONY: verify-manifests
+verify-gen: build-manifests
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make generate"; exit 1; \
+	fi
+
+.PHONY: verify-vendor
+verify-vendor: vendor
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make generate"; exit 1; \
+	fi

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
-	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 // indirect
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.23.0
 	k8s.io/apiserver v0.23.0 // indirect


### PR DESCRIPTION
This PR adds a new workflow "verify", that runs `make vendor` and `make build-manifests` and compares diffs to ensure that we don't forget to run any of them.