### PR TITLE
[controller_runtime] add Secret name reference to the ServiceAccount

### DIFF
--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -235,6 +235,11 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 				elementalv1.ElementalManagedLabel: "",
 			},
 		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name: mRegistration.Name + "-token",
+			},
+		},
 	}); err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create service account: %w", err)
 	}


### PR DESCRIPTION
Otherwise we will have no Secrets in the ServiceAccount for kubernetes clusters >= 1.24

Fixes: #246