### PR TITLE
Use custom name for upgrade objects

### DIFF
--- a/pkg/controllers/managedos/managedos.go
+++ b/pkg/controllers/managedos/managedos.go
@@ -93,12 +93,12 @@ func (h *handler) OnChange(mos *elm.ManagedOSImage, status elm.ManagedOSImageSta
 
 	bundle := &v1alpha1.Bundle{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName("mos", mos.Name),
+			Name:      name.SafeConcatName("mos", mos.Name, string(mos.UID)),
 			Namespace: mos.Namespace,
 		},
 		Spec: v1alpha1.BundleSpec{
 			Resources:               resources,
-			BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{},
+			BundleDeploymentOptions: v1alpha1.BundleDeploymentOptions{DefaultNamespace: mos.Namespace},
 			RolloutStrategy:         mos.Spec.ClusterRolloutStrategy,
 			Targets:                 mos.Spec.Targets,
 		},


### PR DESCRIPTION
Instead of the same everywhere construct the name based of the manageosImage object

Signed-off-by: Itxaka <igarcia@suse.com>