### PR TITLE
Improve syncer

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -80,7 +80,10 @@ const (
 	// SyncingReason documents that managed OS version channel is synchronizing managed OS versions
 	SyncingReason = "Synchronizing"
 
-	// SyncedReason documents that managed OS version channel finalized synchroniziation
+	// GotChannelDataReason documents that managed OS version channel successfully fetched managed OS versions data
+	GotChannelDataReason = "GotChannelData"
+
+	// SyncedReason documents that managed OS version channel finalized synchroniziation and managed OS versions, if any, were created
 	SyncedReason = "Synchronized"
 
 	// FailedToSyncReason documents that managed OS version channel failed synchronization

--- a/api/v1beta1/managedosversionchannel_types.go
+++ b/api/v1beta1/managedosversionchannel_types.go
@@ -49,8 +49,13 @@ type ManagedOSVersionChannelSpec struct {
 type ManagedOSVersionChannelStatus struct {
 	// Conditions describe the state of the managed OS version object.
 	// +optional
-	Conditions     []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
-	LastSyncedTime *metav1.Time       `json:"lastSyncedTime,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+	// LastSyncedTime is the timestamp of the last synchronization
+	// +optional
+	LastSyncedTime *metav1.Time `json:"lastSyncedTime,omitempty"`
+	// Failures field stores the number of consecutive failed attempts to synchronize. Invalid configurations are not counted
+	// +optional
+	Failures uint32 `json:"failures,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -2050,7 +2050,13 @@ spec:
                   - type
                   type: object
                 type: array
+              failures:
+                description: Failures field stores the number of consecutive failed
+                  attempts to synchronize. Invalid configurations are not counted
+                format: int32
+                type: integer
               lastSyncedTime:
+                description: LastSyncedTime is the timestamp of the last synchronization
                 format: date-time
                 type: string
             type: object

--- a/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
@@ -274,7 +274,13 @@ spec:
                   - type
                   type: object
                 type: array
+              failures:
+                description: Failures field stores the number of consecutive failed
+                  attempts to synchronize. Invalid configurations are not counted
+                format: int32
+                type: integer
               lastSyncedTime:
+                description: LastSyncedTime is the timestamp of the last synchronization
                 format: date-time
                 type: string
             type: object

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -157,6 +157,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 	vers, err := sync.Sync(ctx, r.Client, managedOSVersionChannel)
 	if err != nil {
 		failCount++
+		logger.Error(err, "Synchronization failed")
 		if failCount >= maxRetries {
 			// Failed syncing, forget about it until the next interval
 			meta.SetStatusCondition(&managedOSVersionChannel.Status.Conditions, metav1.Condition{
@@ -190,6 +191,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 	err = r.syncVersions(ctx, vers, managedOSVersionChannel)
 	if err != nil {
 		failCount++
+		logger.Error(err, "Failed creating managed os version resources")
 		if failCount >= maxRetries {
 			// Failed syncing, forget about it until the next interval
 			meta.SetStatusCondition(&managedOSVersionChannel.Status.Conditions, metav1.Condition{

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -34,7 +34,8 @@ const (
 )
 
 type Syncer interface {
-	Sync(ctx context.Context, cl client.Client, ch *elementalv1.ManagedOSVersionChannel) ([]elementalv1.ManagedOSVersion, bool, error)
+	// Sync function returns a list of managed os versions and sets the ready condition of the channel status accordingly
+	Sync(ctx context.Context, cl client.Client, ch *elementalv1.ManagedOSVersionChannel) ([]elementalv1.ManagedOSVersion, error)
 }
 
 type Provider interface {


### PR DESCRIPTION
This PR adds few changes on the syncer logic:

* Makes use of ManagedOSVersionChannel status reason to track if there is an on going synchronization rather than polling for the existence of a synchronization pod or not.
* Adds a logic to stop trying to synchronize after 4 consecutive attempts. If it exceeds the maximum it just programs the next re-sync after the given sync interval instead of immediately retrying.
* Adds some logging and comments here and there.