### PR TITLE
Several improvements to the support command

### DIFF
--- a/cmd/support/main.go
+++ b/cmd/support/main.go
@@ -174,7 +174,7 @@ func run() (err error) {
 			describeK8sResource(crd, tempDir)
 		}
 		// get k8s logs
-		for _, namespace := range []string{"cattle-system", "kube-system", "ingress-nginx", "calico-system"} {
+		for _, namespace := range []string{"cattle-system", "kube-system", "ingress-nginx", "calico-system", "cattle-fleet-system"} {
 			logrus.Infof("Getting k8s logs for namespace %s", namespace)
 			getK8sPodsLogs(namespace, tempDir)
 		}

--- a/cmd/support/main.go
+++ b/cmd/support/main.go
@@ -41,7 +41,7 @@ const (
 	k3sKubeConfig         = "/etc/rancher/k3s/k3s.yaml"
 	k3sKubectl            = "/usr/local/bin/kubectl"
 	rkeKubeConfig         = "/etc/rancher/rke2/rke2.yaml"
-	rkeKubeclt            = "/var/lib/rancher/rke2/bin/kubectl"
+	rkeKubectl            = "/var/lib/rancher/rke2/bin/kubectl"
 	elementalAgentPlanDir = "/var/lib/elemental/agent/applied/"
 	rancherAgentPlanDir   = "/var/lib/rancher/agent/applied/"
 	rancherAgentConf      = "/etc/rancher/agent/config.yaml"
@@ -528,9 +528,9 @@ func getKubectl() (string, error) {
 		logrus.Infof("Found k3s kubectl at %s", k3sKubectl)
 		return k3sKubectl, nil
 	}
-	if existsNoWarn(rkeKubeclt) {
-		logrus.Infof("Found rke kubectl at %s", rkeKubeclt)
-		return rkeKubeclt, nil
+	if existsNoWarn(rkeKubectl) {
+		logrus.Infof("Found rke kubectl at %s", rkeKubectl)
+		return rkeKubectl, nil
 	}
 
 	return "", errors.New("Cant find kubectl")


### PR DESCRIPTION
 - Remove : from names as it may not be supported on some systems
 - Fix kubectl finding
 - Fix missing kubeconfig in one command
 - Store also the resources description
 - Add apps, jobs and plans
 - Check kubectl/kubeconfig just once
 - Add missing namespaces
 - Add NetworkManager log

Signed-off-by: Itxaka <igarcia@suse.com>