### PR TITLE
Add a rate limiter to managedosversionchannel reconciler

### DIFF
--- a/api/v1beta1/managedosversionchannel_types.go
+++ b/api/v1beta1/managedosversionchannel_types.go
@@ -53,9 +53,6 @@ type ManagedOSVersionChannelStatus struct {
 	// LastSyncedTime is the timestamp of the last synchronization
 	// +optional
 	LastSyncedTime *metav1.Time `json:"lastSyncedTime,omitempty"`
-	// Failures field stores the number of consecutive failed attempts to synchronize. Invalid configurations are not counted
-	// +optional
-	Failures uint32 `json:"failures,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -2050,11 +2050,6 @@ spec:
                   - type
                   type: object
                 type: array
-              failures:
-                description: Failures field stores the number of consecutive failed
-                  attempts to synchronize. Invalid configurations are not counted
-                format: int32
-                type: integer
               lastSyncedTime:
                 description: LastSyncedTime is the timestamp of the last synchronization
                 format: date-time

--- a/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
@@ -274,11 +274,6 @@ spec:
                   - type
                   type: object
                 type: array
-              failures:
-                description: Failures field stores the number of consecutive failed
-                  attempts to synchronize. Invalid configurations are not counted
-                format: int32
-                type: integer
               lastSyncedTime:
                 description: LastSyncedTime is the timestamp of the last synchronization
                 format: date-time

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -184,7 +184,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 			Message: "Failed syncing channel",
 		})
 		managedOSVersionChannel.Status.Failures = failCount
-		return reconcile.Result{}, err
+		return reconcile.Result{Requeue: true}, err
 	}
 
 	// Check if the synchronization is already running
@@ -218,7 +218,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 			Message: "Failed creating managed OS versions",
 		})
 		managedOSVersionChannel.Status.Failures = failCount
-		return reconcile.Result{}, err
+		return reconcile.Result{Requeue: true}, err
 	}
 
 	meta.SetStatusCondition(&managedOSVersionChannel.Status.Conditions, metav1.Condition{

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -39,8 +39,6 @@ import (
 const baseRateTime = 1 * time.Second
 const maxDelayTime = 256 * time.Second
 
-//const maxRetries = 5
-
 // ManagedOSVersionChannelReconciler reconciles a ManagedOSVersionChannel object.
 type ManagedOSVersionChannelReconciler struct {
 	client.Client

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -174,7 +174,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 			})
 			managedOSVersionChannel.Status.LastSyncedTime = &now
 			managedOSVersionChannel.Status.Failures = 0
-			return reconcile.Result{RequeueAfter: interval}, err
+			return reconcile.Result{RequeueAfter: interval}, nil
 		}
 		// Requeue syncing and increment failures counter
 		meta.SetStatusCondition(&managedOSVersionChannel.Status.Conditions, metav1.Condition{
@@ -190,6 +190,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 	// Check if the synchronization is already running
 	readyCondition := meta.FindStatusCondition(managedOSVersionChannel.Status.Conditions, elementalv1.ReadyCondition)
 	if readyCondition != nil && readyCondition.Reason == elementalv1.SyncingReason {
+		managedOSVersionChannel.Status.Failures = 0
 		return reconcile.Result{Requeue: true}, nil
 	}
 
@@ -208,7 +209,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 			})
 			managedOSVersionChannel.Status.LastSyncedTime = &now
 			managedOSVersionChannel.Status.Failures = 0
-			return reconcile.Result{RequeueAfter: interval}, err
+			return reconcile.Result{RequeueAfter: interval}, nil
 		}
 		// Requeue syncing and increment failures counter
 		meta.SetStatusCondition(&managedOSVersionChannel.Status.Conditions, metav1.Condition{
@@ -227,6 +228,7 @@ func (r *ManagedOSVersionChannelReconciler) reconcile(ctx context.Context, manag
 		Status: metav1.ConditionTrue,
 	})
 	managedOSVersionChannel.Status.LastSyncedTime = &now
+	managedOSVersionChannel.Status.Failures = 0
 
 	return ctrl.Result{RequeueAfter: interval}, nil
 }

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -149,6 +149,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
+		Expect(res.Requeue).To(BeFalse())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -176,6 +177,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
+		Expect(res.Requeue).To(BeFalse())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -204,6 +206,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
+		Expect(res.Requeue).To(BeFalse())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -233,6 +236,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
+		Expect(res.Requeue).To(BeFalse())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -261,7 +265,8 @@ var _ = Describe("reconcile managed os version channel", func() {
 			},
 		})
 		Expect(err).To(HaveOccurred())
-		Expect(res.RequeueAfter).To(Equal(5 * time.Second))
+		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
+		Expect(res.Requeue).To(BeFalse())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -295,7 +300,8 @@ var _ = Describe("reconcile managed os version channel", func() {
 		for i := 1; i < maxRetries; i++ {
 			res, err := r.Reconcile(ctx, req)
 			Expect(err).To(HaveOccurred())
-			Expect(res.RequeueAfter).To(Equal(5 * time.Second))
+			Expect(res.RequeueAfter).To(Equal(0 * time.Second))
+			Expect(res.Requeue).To(BeFalse())
 
 			Expect(cl.Get(ctx, objKey, managedOSVersionChannel)).To(Succeed())
 
@@ -311,6 +317,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		res, err := r.Reconcile(ctx, req)
 		Expect(err).To(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(1 * time.Minute))
+		Expect(res.Requeue).To(BeFalse())
 
 		Expect(cl.Get(ctx, objKey, managedOSVersionChannel)).To(Succeed())
 

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -95,20 +95,20 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(test.CleanupAndWait(ctx, cl, managedOSVersionChannel)).To(Succeed())
 	})
 
-	It("should reconcile and sync managed os version channel object", func() {
+	It("should reconcile and sync managed os version channel object (synchronous)", func() {
 		managedOSVersion := &elementalv1.ManagedOSVersion{}
 		managedOSVersionChannel.Spec.Type = "custom"
 		managedOSVersionChannel.Spec.SyncInterval = "1m"
+		name := types.NamespacedName{
+			Namespace: managedOSVersionChannel.Namespace,
+			Name:      managedOSVersionChannel.Name,
+		}
 		Expect(cl.Create(ctx, managedOSVersionChannel)).To(Succeed())
 
-		res1, err := r.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: managedOSVersionChannel.Namespace,
-				Name:      managedOSVersionChannel.Name,
-			},
-		})
+		// No error and status updated (triggers requeue)
+		res1, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(res1.RequeueAfter).Should(BeNumerically(">", 50*time.Second))
+		Expect(res1.RequeueAfter).To(Equal(0 * time.Second))
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -119,22 +119,82 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(managedOSVersionChannel.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.SyncedReason))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(0)))
+
+		// No status update, hence the requeue is delayed until next interval
+		res1, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res1.RequeueAfter).Should(BeNumerically(">", 50*time.Second))
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      "v0.1.0",
 			Namespace: managedOSVersionChannel.Namespace,
 		}, managedOSVersion)).To(Succeed())
 
-		res2, err := r.Reconcile(ctx, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: managedOSVersionChannel.Namespace,
-				Name:      managedOSVersionChannel.Name,
-			},
-		})
+		// No status update, hence the requeue is delayed again until next interval
+		res2, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res2.RequeueAfter).Should(BeNumerically("<", res1.RequeueAfter))
 		Expect(res2.RequeueAfter).Should(BeNumerically(">", 50*time.Second))
+	})
+
+	It("should reconcile and sync managed os version channel object (asynchronous)", func() {
+		syncerProvider.Asynchronous = true
+		managedOSVersion := &elementalv1.ManagedOSVersion{}
+		managedOSVersionChannel.Spec.Type = "custom"
+		managedOSVersionChannel.Spec.SyncInterval = "1m"
+		name := types.NamespacedName{
+			Namespace: managedOSVersionChannel.Namespace,
+			Name:      managedOSVersionChannel.Name,
+		}
+		Expect(cl.Create(ctx, managedOSVersionChannel)).To(Succeed())
+
+		// No error and status updated (triggers requeue) loop #1
+		res1, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res1.RequeueAfter).To(Equal(0 * time.Second))
+
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Name:      managedOSVersionChannel.Name,
+			Namespace: managedOSVersionChannel.Namespace,
+		}, managedOSVersionChannel)).To(Succeed())
+
+		Expect(managedOSVersionChannel.Status.Conditions).To(HaveLen(1))
+		Expect(managedOSVersionChannel.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
+		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.SyncingReason))
+		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
+
+		// No status update, forced requeue loop #2
+		res1, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res1.RequeueAfter).To(Equal(0 * time.Second))
+		Expect(res1.Requeue).To(BeTrue())
+
+		// Status update, no forced requeue loop #3
+		res1, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res1.RequeueAfter).To(Equal(0 * time.Second))
+		//Expect(res1.Requeue).To(BeFalse())
+
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Name:      managedOSVersionChannel.Name,
+			Namespace: managedOSVersionChannel.Namespace,
+		}, managedOSVersionChannel)).To(Succeed())
+
+		Expect(managedOSVersionChannel.Status.Conditions).To(HaveLen(1))
+		Expect(managedOSVersionChannel.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
+		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.SyncedReason))
+		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+
+		// Now the managed os vesion is already created
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Name:      "v0.1.0",
+			Namespace: managedOSVersionChannel.Namespace,
+		}, managedOSVersion)).To(Succeed())
+
+		// No status update, hence the requeue is delayed again until next interval
+		res1, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res1.RequeueAfter).Should(BeNumerically(">", 50*time.Second))
 	})
 
 	It("should reconcile managed os version channel object without a type", func() {
@@ -161,8 +221,6 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.InvalidConfigurationReason))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("spec.Type can't be empty"))
-		// Only synchronization failures are counted, not configuration issues
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(0)))
 	})
 
 	It("should reconcile managed os version channel object without a sync interval", func() {
@@ -189,8 +247,6 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.InvalidConfigurationReason))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("spec.SyncInterval is not parseable"))
-		// Only synchronization failures are counted, not configuration issues
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(0)))
 	})
 
 	It("should reconcile managed os version channel object with a not valid sync interval", func() {
@@ -218,8 +274,6 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.InvalidConfigurationReason))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("spec.SyncInterval is not parseable"))
-		// Only synchronization failures are counted, not configuration issues
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(0)))
 	})
 
 	It("should reconcile managed os version channel object with a not valid type", func() {
@@ -248,8 +302,6 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.InvalidConfigurationReason))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("failed to create a syncer"))
-		// Only synchronization failures are counted, not configuration issues
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(0)))
 	})
 
 	It("it fails to reconcile a managed os version channel when channel provides invalid JSON", func() {
@@ -266,7 +318,6 @@ var _ = Describe("reconcile managed os version channel", func() {
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
-		Expect(res.Requeue).To(BeTrue())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -278,55 +329,5 @@ var _ = Describe("reconcile managed os version channel", func() {
 		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.FailedToSyncReason))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 		Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("Failed syncing channel"))
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(1)))
-	})
-
-	It("it counts failures until retries are over", func() {
-		syncerProvider.JSON = invalidJSON
-		managedOSVersionChannel.Spec.Type = "json"
-		managedOSVersionChannel.Spec.SyncInterval = "1m"
-		Expect(cl.Create(ctx, managedOSVersionChannel)).To(Succeed())
-		req := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: managedOSVersionChannel.Namespace,
-				Name:      managedOSVersionChannel.Name,
-			},
-		}
-		objKey := client.ObjectKey{
-			Name:      managedOSVersionChannel.Name,
-			Namespace: managedOSVersionChannel.Namespace,
-		}
-
-		for i := 1; i < maxRetries; i++ {
-			res, err := r.Reconcile(ctx, req)
-			Expect(err).To(HaveOccurred())
-			Expect(res.RequeueAfter).To(Equal(0 * time.Second))
-			Expect(res.Requeue).To(BeTrue())
-
-			Expect(cl.Get(ctx, objKey, managedOSVersionChannel)).To(Succeed())
-
-			Expect(managedOSVersionChannel.Status.Conditions).To(HaveLen(1))
-			Expect(managedOSVersionChannel.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-			Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.FailedToSyncReason))
-			Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-			Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("Failed syncing channel"))
-			Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(i)))
-			Expect(managedOSVersionChannel.Status.LastSyncedTime).To(BeNil())
-		}
-
-		res, err := r.Reconcile(ctx, req)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(res.RequeueAfter).To(Equal(1 * time.Minute))
-		Expect(res.Requeue).To(BeFalse())
-
-		Expect(cl.Get(ctx, objKey, managedOSVersionChannel)).To(Succeed())
-
-		Expect(managedOSVersionChannel.Status.Conditions).To(HaveLen(1))
-		Expect(managedOSVersionChannel.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(managedOSVersionChannel.Status.Conditions[0].Reason).To(Equal(elementalv1.FailedToSyncReason))
-		Expect(managedOSVersionChannel.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-		Expect(managedOSVersionChannel.Status.Conditions[0].Message).To(ContainSubstring("Failed syncing channel"))
-		Expect(managedOSVersionChannel.Status.Failures).To(Equal(uint32(0)))
-		Expect(managedOSVersionChannel.Status.LastSyncedTime).NotTo(BeNil())
 	})
 })

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -315,7 +315,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		}
 
 		res, err := r.Reconcile(ctx, req)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ShouldNot(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(1 * time.Minute))
 		Expect(res.Requeue).To(BeFalse())
 

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -266,7 +266,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(res.RequeueAfter).To(Equal(0 * time.Second))
-		Expect(res.Requeue).To(BeFalse())
+		Expect(res.Requeue).To(BeTrue())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
 			Name:      managedOSVersionChannel.Name,
@@ -301,7 +301,7 @@ var _ = Describe("reconcile managed os version channel", func() {
 			res, err := r.Reconcile(ctx, req)
 			Expect(err).To(HaveOccurred())
 			Expect(res.RequeueAfter).To(Equal(0 * time.Second))
-			Expect(res.Requeue).To(BeFalse())
+			Expect(res.Requeue).To(BeTrue())
 
 			Expect(cl.Get(ctx, objKey, managedOSVersionChannel)).To(Succeed())
 

--- a/tests/catalog/managedosversionchannel.go
+++ b/tests/catalog/managedosversionchannel.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package catalog
 
+import (
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
 type ManagedOSVersionChannelSpec struct {
 	Type             string                 `json:"type" yaml:"type"`
 	Options          map[string]interface{} `json:"options" yaml:"options"`
@@ -32,7 +39,26 @@ type ManagedOSVersionChannel struct {
 	Spec ManagedOSVersionChannelSpec `json:"spec,omitempty"`
 }
 
-func NewManagedOSVersionChannel(name string, t string, interval string, options map[string]interface{}, upgradeContainer *ContainerSpec) *ManagedOSVersionChannel {
+func NewManagedOSVersionChannel(namespace, name, sType, interval string, options map[string]runtime.RawExtension, upgradeContainer *upgradev1.ContainerSpec) *elementalv1.ManagedOSVersionChannel {
+	return &elementalv1.ManagedOSVersionChannel{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "elemental.cattle.io/v1beta1",
+			Kind:       "ManagedOSVersionChannel",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: elementalv1.ManagedOSVersionChannelSpec{
+			Type:             sType,
+			SyncInterval:     interval,
+			Options:          options,
+			UpgradeContainer: upgradeContainer,
+		},
+	}
+}
+
+func LegacyNewManagedOSVersionChannel(name string, t string, interval string, options map[string]interface{}, upgradeContainer *ContainerSpec) *ManagedOSVersionChannel {
 	return &ManagedOSVersionChannel{
 		APIVersion: "elemental.cattle.io/v1beta1",
 		Metadata: struct {

--- a/tests/e2e/managedosversionchannel_test.go
+++ b/tests/e2e/managedosversionchannel_test.go
@@ -219,7 +219,7 @@ var _ = Describe("ManagedOSVersionChannel e2e tests", func() {
 					return string(v.Spec.Metadata["upgradeImage"].Raw)
 				}
 				return ""
-			}, 5*time.Minute, 2*time.Second).Should(
+			}, 4*time.Minute, 2*time.Second).Should(
 				Equal(`"registry.com/repository/image:v1"`),
 			)
 
@@ -233,40 +233,8 @@ var _ = Describe("ManagedOSVersionChannel e2e tests", func() {
 					return string(v.Spec.Metadata["upgradeImage"].Raw)
 				}
 				return ""
-			}, 1*time.Minute, 2*time.Second).Should(
+			}, 10*time.Second, 2*time.Second).Should(
 				Equal(`"registry.com/repository/image:v2"`),
-			)
-		})
-
-		It("on a broken a channel it stops on failed sync ready reason", func() {
-			command, _ := json.Marshal([]string{"/bin/bash", "-c", "--"})
-			args, _ := json.Marshal([]string{fmt.Sprintf("echo '%s' > /output/data", string("wrong content"))})
-
-			By("Create a ManagedOSVersionChannel with wrong content")
-			ch := catalog.NewManagedOSVersionChannel(
-				fleetNamespace, channelName, "custom", "10m",
-				map[string]runtime.RawExtension{
-					"image":   {Raw: []byte(`"opensuse/tumbleweed"`)},
-					"command": {Raw: command},
-					"args":    {Raw: args},
-				}, nil,
-			)
-
-			Expect(cl.Create(ctx, ch)).To(Succeed())
-
-			Eventually(func() string {
-				gCh := &elementalv1.ManagedOSVersionChannel{}
-				_ = cl.Get(ctx, client.ObjectKey{
-					Name:      "testchannel",
-					Namespace: fleetNamespace,
-				}, gCh)
-
-				if len(gCh.Status.Conditions) > 0 && gCh.Status.Conditions[0].Status == metav1.ConditionTrue {
-					return gCh.Status.Conditions[0].Message
-				}
-				return ""
-			}, 1*time.Minute, 2*time.Second).Should(
-				ContainSubstring("Failed syncing channel"),
 			)
 		})
 	})

--- a/tests/e2e/upgrades_test.go
+++ b/tests/e2e/upgrades_test.go
@@ -221,7 +221,7 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 		})
 
 		It("applies an os-upgrade from a channel", func() {
-			mr := catalog.NewManagedOSVersionChannel(
+			mr := catalog.LegacyNewManagedOSVersionChannel(
 				"testchannel3",
 				"custom",
 				"1m",
@@ -263,7 +263,7 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 		})
 
 		It("overwrites default container spec from a channel", func() {
-			mr := catalog.NewManagedOSVersionChannel(
+			mr := catalog.LegacyNewManagedOSVersionChannel(
 				"testchannel4",
 				"custom",
 				"1m",
@@ -309,7 +309,7 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 		})
 
 		It("tries to apply an upgrade", func() {
-			mr := catalog.NewManagedOSVersionChannel(
+			mr := catalog.LegacyNewManagedOSVersionChannel(
 				"testchannel5",
 				"custom",
 				"1m",


### PR DESCRIPTION
This commit adds a rate limiter to the ManagedOSVersionChannel controller to prevent stacking reconcile loops over the same resource in fast rates (doesn't make sense for a ManagedOSVersionChannel). By default the controller runtime already includes an equivalent rate limiter, but starts in the range of milliseconds, starting the exponential rate limiter in the range of seconds is more than enough in this context.

In addition it drops the failures counter in the resource. This counter was supposed to be used to limit the number attempts to sync in case of failure. This was a bad design, status should not keep a counter like this as any change in status triggers a new immediate reconcile loop, hence the counter was reaching the maximum as fast as the controller runtime was executing reconcile loops without any rate limiter (rate limiter applies only when there are no changes including status).

For now I think we can just live without the setting any maxium for failures. If we ever need it I believe it should be coded and tracked within the controller itself, not in each resource as this prevents the reconcile loop of being idempotent. Alternatively we could prevent triggering the reconcile loop on status changes, however this prevents reconciling if any third party (or user from the kubectl client) changes a resource status.

Fixes #257
Part of #240

Signed-off-by: David Cassany <dcassany@suse.com>