### PR TITLE
Add version commands/flags for all binaries

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	displayCmd "github.com/rancher/elemental-operator/cmd/operator/display"
 	operatorCmd "github.com/rancher/elemental-operator/cmd/operator/operator"
+	"github.com/rancher/elemental-operator/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -31,9 +32,22 @@ func main() {
 
 	cmd.AddCommand(
 		operatorCmd.NewOperatorCommand(),
-		displayCmd.NewDisplayCommand())
+		displayCmd.NewDisplayCommand(),
+		NewVersionCommand(),
+	)
 
 	if err := cmd.Execute(); err != nil {
 		logrus.Fatalln(err)
 	}
+}
+
+func NewVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print operator version",
+		Run: func(_ *cobra.Command, _ []string) {
+			logrus.Infof("Operator version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
+		},
+	}
+	return cmd
 }

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -62,7 +62,13 @@ func main() {
 			if debug {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
+			if viper.GetBool("version") {
+				logrus.Infof("Support version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
+				return
+			}
+
 			logrus.Infof("Register version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
+
 			if len(args) == 0 {
 				args = append(args, regConfDir)
 			}
@@ -110,7 +116,9 @@ func main() {
 	cmd.Flags().BoolVar(&cfg.Elemental.Registration.EmulateTPM, "emulate-tpm", false, "Emulate /dev/tpm")
 	cmd.Flags().Int64Var(&cfg.Elemental.Registration.EmulatedTPMSeed, "emulated-tpm-seed", 1, "Seed for /dev/tpm emulation")
 	cmd.Flags().BoolVar(&cfg.Elemental.Registration.NoSMBIOS, "no-smbios", false, "Disable the use of dmidecode to get SMBIOS")
-	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug logging")
+	cmd.Flags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
+	cmd.PersistentFlags().BoolP("version", "v", false, "print version and exit")
+	_ = viper.BindPFlag("version", cmd.PersistentFlags().Lookup("version"))
 
 	if err := cmd.Execute(); err != nil {
 		logrus.Fatalln(err)

--- a/cmd/support/main.go
+++ b/cmd/support/main.go
@@ -84,13 +84,19 @@ func main() {
 			if viper.GetBool("debug") {
 				logrus.SetLevel(logrus.DebugLevel)
 			}
+			if viper.GetBool("version") {
+				logrus.Infof("Support version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
+				return nil
+			}
 			logrus.Infof("Support version %s, commit %s, commit date %s", version.Version, version.Commit, version.CommitDate)
 			return run()
 		},
 	}
 
-	cmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
+	cmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging")
+	cmd.PersistentFlags().BoolP("version", "v", false, "print version and exit")
 	_ = viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))
+	_ = viper.BindPFlag("version", cmd.PersistentFlags().Lookup("version"))
 
 	if err := cmd.Execute(); err != nil {
 		logrus.Fatalln(err)


### PR DESCRIPTION
Easy way of getting the version only. A flag for register/support and a subcommand for the operator

Fixes #261 

Signed-off-by: Itxaka <igarcia@suse.com>