### PR TITLE
[tpm] rework emulation tpm to use random seed

### DIFF
--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
@@ -40,6 +41,10 @@ func Register(url string, caCert []byte, smbios bool, emulateTPM bool, emulatedS
 	tpmAuth := &tpm.AuthClient{}
 	if emulateTPM {
 		logrus.Info("Enable TPM emulation")
+		if emulatedSeed == -1 {
+			emulatedSeed = rand.Int63()
+			logrus.Debugf("TPM emulation set to -1, setting random seed: %d", emulatedSeed)
+		}
 		tpmAuth.EmulateTPM(emulatedSeed)
 	}
 


### PR DESCRIPTION
There is no point on having a static seed for the registration when working with emualted tpm. In fact, once the registration is done the seed value is never used again so why not just use a random value onr egister and drop that config?

This makes several machines with emulated tpm work with just one registration+iso and has no downsides that I can see

Signed-off-by: Itxaka <igarcia@suse.com>