### PR TITLE
Kubebuilder: Remove invalid conditions from objects

### DIFF
--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -77,6 +78,9 @@ func (r *MachineInventoryReconciler) Reconcile(ctx context.Context, req reconcil
 	}
 
 	patchBase := client.MergeFrom(mInventory.DeepCopy())
+
+	// We have to sanitize the conditions because old API definitions didn't have proper validation.
+	mInventory.Status.Conditions = util.RemoveInvalidConditions(mInventory.Status.Conditions)
 
 	// Collect errors as an aggregate to return together after all patches have been performed.
 	var errs []error

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/util"
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/randomtoken"
 	corev1 "k8s.io/api/core/v1"
@@ -74,6 +75,9 @@ func (r *MachineRegistrationReconciler) Reconcile(ctx context.Context, req recon
 	}
 
 	patchBase := client.MergeFrom(mRegistration.DeepCopy())
+
+	// We have to sanitize the conditions because old API definitions didn't have proper validation.
+	mRegistration.Status.Conditions = util.RemoveInvalidConditions(mRegistration.Status.Conditions)
 
 	// Collect errors as an aggregate to return together after all patches have been performed.
 	var errs []error

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/util"
 	"github.com/rancher/system-agent/pkg/applyinator"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -85,6 +86,9 @@ func (r *MachineInventorySelectorReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	patchBase := client.MergeFrom(machineInventorySelector.DeepCopy())
+
+	// We have to sanitize the conditions because old API definitions didn't have proper validation.
+	machineInventorySelector.Status.Conditions = util.RemoveInvalidConditions(machineInventorySelector.Status.Conditions)
 
 	// Collect errors as an aggregate to return together after all patches have been performed.
 	var errs []error

--- a/controllers/managedosimage_controller.go
+++ b/controllers/managedosimage_controller.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/util"
 	fleetv1 "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	upgradev1 "github.com/rancher/system-upgrade-controller/pkg/apis/upgrade.cattle.io/v1"
 	"github.com/rancher/wrangler/pkg/name"
@@ -90,6 +91,9 @@ func (r *ManagedOSImageReconciler) Reconcile(ctx context.Context, req reconcile.
 	}
 
 	patchBase := client.MergeFrom(managedOSImage.DeepCopy())
+
+	// We have to sanitize the conditions because old API definitions didn't have proper validation.
+	managedOSImage.Status.Conditions = util.RemoveInvalidConditions(managedOSImage.Status.Conditions)
 
 	// Collect errors as an aggregate to return together after all patches have been performed.
 	var errs []error

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -23,6 +23,7 @@ import (
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/syncer"
+	"github.com/rancher/elemental-operator/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,6 +81,9 @@ func (r *ManagedOSVersionChannelReconciler) Reconcile(ctx context.Context, req r
 	}
 
 	patchBase := client.MergeFrom(managedOSVersionChannel.DeepCopy())
+
+	// We have to sanitize the conditions because old API definitions didn't have proper validation.
+	managedOSVersionChannel.Status.Conditions = util.RemoveInvalidConditions(managedOSVersionChannel.Status.Conditions)
 
 	// Collect errors as an aggregate to return together after all patches have been performed.
 	var errs []error

--- a/pkg/util/suite_test.go
+++ b/pkg/util/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func RemoveInvalidConditions(conditions []metav1.Condition) []metav1.Condition {
+	newConditions := []metav1.Condition{}
+	for _, cond := range conditions {
+		if cond.Type == "" || cond.Status == "" || cond.LastTransitionTime.IsZero() || cond.Reason == "" {
+			continue
+		}
+		newConditions = append(newConditions, cond)
+	}
+	return newConditions
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2022 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("removeInvalidConditions", func() {
+	It("should remove invalid conditions", func() {
+		cond := RemoveInvalidConditions([]metav1.Condition{
+			{
+				Type:               elementalv1.ReadyCondition,
+				Reason:             elementalv1.WaitingForPlanReason,
+				Message:            "Test message",
+				LastTransitionTime: metav1.Now(),
+				Status:             metav1.ConditionUnknown,
+			},
+			{
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Ready",
+			},
+			{
+				Type:               "InvalidCondition",
+				LastTransitionTime: metav1.Now(),
+				Reason:             "Ready",
+			},
+			{
+				Type:   "InvalidCondition",
+				Status: metav1.ConditionFalse,
+				Reason: "Ready",
+			},
+			{
+				Type:               "InvalidCondition",
+				Status:             metav1.ConditionFalse,
+				LastTransitionTime: metav1.Now(),
+			},
+		})
+
+		Expect(cond).To(HaveLen(1))
+		Expect(cond[0].Type).To(Equal(elementalv1.ReadyCondition))
+		Expect(cond[0].Status).To(Equal(metav1.ConditionUnknown))
+		Expect(cond[0].Reason).To(Equal(elementalv1.WaitingForPlanReason))
+		Expect(cond[0].LastTransitionTime).NotTo(BeZero())
+	})
+})


### PR DESCRIPTION
This PR sanitizes conditions on all objects. The previous implementation doesn't have any validation for conditions and after the upgrade, we might be getting invalid values. Let's remove all invalid conditions from objects, reconcile loop will set proper conditions anyway later.

More context: https://github.com/rancher/elemental-operator/issues/241#issuecomment-1337661833