### PR TITLE
Kubebuilder: fix MachineRegistration search during registration

### DIFF
--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -594,12 +594,12 @@ func hasMatchingLabels(ctx context.Context, miSelector *elementalv1.MachineInven
 	}
 
 	if selector.Empty() {
-		log.V(5).Info("machine selector has empty selector", "mInventory.Name", miSelector.Name)
+		log.V(5).Info("machine selector has empty selector", "mSelector.Name", miSelector.Name)
 		return false
 	}
 
 	if !selector.Matches(labels.Set(mInventory.Labels)) {
-		log.V(5).Info("machine inventory has mismatch labels", "mInventory.Name", mInventory.Name)
+		log.V(5).Info("machine inventory has mismatch labels", "mInventory.Name", mInventory.Name, "mSelector.Name", miSelector.Name)
 		return false
 	}
 

--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -202,7 +202,7 @@ func (i *InventoryServer) getMachineRegistration(req *http.Request) (*elementalv
 				return nil, fmt.Errorf("machine registrations %s/%s and %s/%s have the same registration token %s",
 					mRegistration.Namespace, mRegistration.Name, m.Namespace, m.Name, escapedToken)
 			}
-			mRegistration = &m
+			mRegistration = (&m).DeepCopy()
 		}
 	}
 


### PR DESCRIPTION
* operator: fix MachineSelector controller log
* operator: fix MachineRegistration search in registration

Fixes #292

Backport from the controller_runtime branch:
https://github.com/rancher/elemental-operator/pull/280

Signed-off-by: Francesco Giudici <francesco.giudici@suse.com>