### PR TITLE
Derive TPM seed from system UUID

### DIFF
--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -49,9 +49,14 @@ func Register(url string, caCert []byte, smbios bool, emulateTPM bool, emulatedS
 			} else {
 				uuid := strings.Replace(data.UUID, "-", "", -1)
 				var i big.Int
-				i.SetString(uuid, 16)
-				emulatedSeed = i.Int64()
-				logrus.Debugf("TPM emulation using system UUID %s, resulting in seed: %d", uuid, emulatedSeed)
+				_, converted := i.SetString(uuid, 16)
+				if !converted {
+					emulatedSeed = rand.Int63()
+					logrus.Debugf("TPM emulation using random seed: %d", emulatedSeed)
+				} else {
+					emulatedSeed = i.Int64()
+					logrus.Debugf("TPM emulation using system UUID %s, resulting in seed: %d", uuid, emulatedSeed)
+				}
 			}
 		}
 		tpmAuth.EmulateTPM(emulatedSeed)


### PR DESCRIPTION
Try first to get the system UUID and derive the seed from there. It still should be unique per system but allows us to reproduce it if needed.

This should be a stepping stone to deprecate setting the random seed manually and resort to always random-seed by default when using emulated TPM

Signed-off-by: Itxaka <igarcia@suse.com>