### PR TITLE
Add disable-boot-entry flag in install structure

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -41,6 +41,8 @@ type Install struct {
 	Reboot bool `json:"reboot,omitempty" yaml:"reboot,omitempty"`
 	// +optional
 	EjectCD bool `json:"eject-cd,omitempty" yaml:"eject-cd,omitempty"`
+	// +optional
+	DisableBootEntry bool `json:"disable-boot-entry,omitempty" yaml:"disable-boot-entry,omitempty"`
 }
 
 type Registration struct {

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -717,6 +717,8 @@ spec:
                             type: boolean
                           device:
                             type: string
+                          disable-boot-entry:
+                            type: boolean
                           eject-cd:
                             type: boolean
                           firmware:

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -51,6 +51,8 @@ spec:
                             type: boolean
                           device:
                             type: string
+                          disable-boot-entry:
+                            type: boolean
                           eject-cd:
                             type: boolean
                           firmware:


### PR DESCRIPTION
Fixes rancher/elemental-operator#296

Signed-off-by: David Cassany <dcassany@suse.com>