### PR TITLE
Re-add config-dir install flag

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -43,6 +43,8 @@ type Install struct {
 	EjectCD bool `json:"eject-cd,omitempty" yaml:"eject-cd,omitempty"`
 	// +optional
 	DisableBootEntry bool `json:"disable-boot-entry,omitempty" yaml:"disable-boot-entry,omitempty"`
+	// +optional
+	ConfigDir string `json:"config-dir,omitempty" yaml:"config-dir,omitempty"`
 }
 
 type Registration struct {

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -709,6 +709,8 @@ spec:
                     properties:
                       install:
                         properties:
+                          config-dir:
+                            type: string
                           config-urls:
                             items:
                               type: string

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -43,6 +43,8 @@ spec:
                     properties:
                       install:
                         properties:
+                          config-dir:
+                            type: string
                           config-urls:
                             items:
                               type: string

--- a/controllers/managedosimage_controller_test.go
+++ b/controllers/managedosimage_controller_test.go
@@ -372,10 +372,15 @@ var _ = Describe("metadataEnv", func() {
 		}
 		env := metadataEnv(envMap)
 		Expect(env).To(HaveLen(2))
-		Expect(env[0].Name).To(Equal("METADATA_UPGRADEIMAGE"))
-		Expect(env[0].Value).To(Equal("registry.com/repository/image:v1.0"))
-		Expect(env[1].Name).To(Equal("METADATA_ROBIN"))
-		Expect(env[1].Value).To(Equal("batman"))
+		for _, e := range env {
+			if e.Name == "METADATA_UPGRADEIMAGE" {
+				Expect(e.Value).To(Equal("registry.com/repository/image:v1.0"))
+			} else {
+				Expect(e.Name).To(Equal("METADATA_ROBIN"))
+				Expect(e.Value).To(Equal("batman"))
+			}
+		}
+
 	})
 
 	It("should container env variables when passed as jsondata", func() {

--- a/pkg/elementalcli/elementalcli.go
+++ b/pkg/elementalcli/elementalcli.go
@@ -30,9 +30,15 @@ func Run(conf map[string]interface{}) error {
 	ev := mapToEnv("ELEMENTAL_INSTALL_", conf)
 
 	installerOpts := []string{"elemental"}
-	// Do we really need this? We already would set ELEMENTAL_DEBUG env var
-	if conf["debug"] == true {
+	// There are no env var bindings in elemental-cli for elemental root options
+	// so root flags should be passed within the command line
+	debug, ok := conf["debug"].(bool)
+	if ok && debug {
 		installerOpts = append(installerOpts, "--debug")
+	}
+	configDir, ok := conf["config-dir"].(string)
+	if ok && configDir != "" {
+		installerOpts = append(installerOpts, "--config-dir", configDir)
 	}
 	installerOpts = append(installerOpts, "install")
 


### PR DESCRIPTION
Noted that `config-dir` options for the install config got lost within the kubebuilder refactor. This is required to be able to pass custom hooks as part of the installation.

Signed-off-by: David Cassany <dcassany@suse.com>