### PR TITLE
Change tar-file layout in elemental-support

### DIFF
--- a/cmd/support/main.go
+++ b/cmd/support/main.go
@@ -31,10 +31,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/rancher/elemental-operator/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/rancher/elemental-operator/pkg/version"
 )
 
 const (
@@ -232,6 +233,7 @@ func compress(src string, buf io.Writer) error {
 		if err != nil {
 			return err
 		}
+
 		if err := tw.WriteHeader(header); err != nil {
 			return err
 		}
@@ -246,12 +248,13 @@ func compress(src string, buf io.Writer) error {
 		_ = filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
 			// generate tar header
 			var header, _ = tar.FileInfoHeader(fi, file)
-			header.Name = filepath.ToSlash(file)
+			header.Name = strings.Replace(filepath.ToSlash(file), "/tmp/", "elemental-support-", 1)
 
 			// write header
 			if err := tw.WriteHeader(header); err != nil {
 				return err
 			}
+
 			// if not a dir, write file content
 			if !fi.IsDir() {
 				data, err := os.Open(file)


### PR DESCRIPTION
Replace `/tmp/` with `elemental-support-`

Example:

```shell
$ tar tf m-d815bd22-6380-4fd6-a85f-120f9
elemental-support-120771762
elemental-support-120771762/NetworkManager.log
elemental-support-120771762/apps-describe.log
elemental-support-120771762/apps-resource.log
elemental-support-120771762/cattle-fleet-system-fleet-agent-d56d4c7b5-9px68-logs.log
elemental-support-120771762/cattle-system-cattle-cluster-agent-59b7cc4768-jb886-logs.log
elemental-support-120771762/cattle-system-system-upgrade-controller-7f9f559b4f-9vl6h-logs.log
elemental-support-120771762/cos-immutable-rootfs.log
elemental-support-120771762/cos-setup-boot.log
...
```

Fixes #205

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>