### PR TITLE
unit-tests: disable parallelization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ validate:
 
 .PHONY: unit-tests
 unit-tests: $(SETUP_ENVTEST) $(GINKGO)
-	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GINKGO) -v -p -r --trace --race --covermode=atomic --coverprofile=coverage.out --coverpkg=github.com/rancher/elemental-operator/... ./pkg/... ./controllers/...
+	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" $(GINKGO) -v -r --trace --race --covermode=atomic --coverprofile=coverage.out --coverpkg=github.com/rancher/elemental-operator/... ./pkg/... ./controllers/...
 
 e2e-tests: $(GINKGO) setup-kind
 	export EXTERNAL_IP=`kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type == "InternalIP")].address}'` && \


### PR DESCRIPTION
The parallelized number of tests is based on the number of available processors only. The memory usage for the controllers unit-test is big and we end up using quite some RAM. If systems with mmany CPUs and not that huge GBs of RAM (my system has 16 cores and 16GB of RAM) we likely start to hit the swap space.
The end result I get is that if I have less than 8GB free my system starts trashing and becomes unresponsive. Even if I have more than 8GB free I consume some swap space and the tests run slower than when serializing tests! ----
$git clean -fdx; time make unit-tests

With parallelization:
real    0m17.477s
user    2m8.029s
sys     0m14.570s

Without parallelization (with this patch):
real    0m14.271s
user    0m27.395s
sys     0m4.659s
