### PR TITLE
Add default config-dir value

### DIFF
--- a/pkg/elementalcli/elementalcli.go
+++ b/pkg/elementalcli/elementalcli.go
@@ -26,6 +26,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const installMediaConfigDir = "/run/initramfs/live/elemental"
+
 func Run(conf map[string]interface{}) error {
 	ev := mapToEnv("ELEMENTAL_INSTALL_", conf)
 
@@ -39,6 +41,9 @@ func Run(conf map[string]interface{}) error {
 	configDir, ok := conf["config-dir"].(string)
 	if ok && configDir != "" {
 		installerOpts = append(installerOpts, "--config-dir", configDir)
+	} else {
+		logrus.Infof("Attempt to load elemental client config from default path: %s", installMediaConfigDir)
+		installerOpts = append(installerOpts, "--config-dir", installMediaConfigDir)
 	}
 	installerOpts = append(installerOpts, "install")
 


### PR DESCRIPTION
This PR sets a default path for the `--config-dir` flag in `elemental install` call during registration. 

This is handy if we want to include some specific `config.yaml` to be honored by the `elemental install`. So by default if an ISO includes `/elemental/config.yaml` in the ISO filesystem it will be loaded. This is helpful to provide specific install configuration within the installation media without having adapt the registration crd.

Signed-off-by: David Cassany <dcassany@suse.com>