### PR TITLE
linter: fix go-header check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters-settings:
     min-complexity: 20 # default is 30 which is too high
   goheader:
     template: |-
-      Copyright © {{year}} SUSE LLC
+      Copyright © {{ year }} SUSE LLC
   
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.


### PR DESCRIPTION
Starting with 2023 we started having false go-header positives. This was due to two things:
1) we need to add history during the checkout, as the go-header linter
   checks if the header in the sources should include the current year
   using 'git log' (if it fails, would check the file stats, but that
   has been just checked out, so will match current year for sure).
2) the current golangci-lint v1.50.1 is more sensible to the yaml
   syntax, in particular to the curly braces: the parser will work
   correctly if the curly braces have a space before (and after) the
   expression to be evaluated.

Signed-off-by: Francesco Giudici <francesco.giudici@suse.com>