### PR TITLE
Do not store cpu info if not available

### DIFF
--- a/pkg/server/register.go
+++ b/pkg/server/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 SUSE LLC
+Copyright © 2023 SUSE LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -499,8 +499,17 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 		inv.Labels = map[string]string{}
 	}
 	inv.Labels["elemental.cattle.io/TotalMemory"] = strconv.Itoa(int(systemData.Memory.TotalPhysicalBytes))
-	inv.Labels["elemental.cattle.io/CpuTotalCores"] = strconv.Itoa(int(systemData.CPU.TotalCores))
-	inv.Labels["elemental.cattle.io/CpuTotalThreads"] = strconv.Itoa(int(systemData.CPU.TotalThreads))
+
+	// Both checks below is due to ghw not detecting aarch64 cores/threads properly, so it ends up in a label
+	// with 0 valuie, which is not useful at all
+	// tracking bug: https://github.com/jaypipes/ghw/issues/199
+	if systemData.CPU.TotalCores > 0 {
+		inv.Labels["elemental.cattle.io/CpuTotalCores"] = strconv.Itoa(int(systemData.CPU.TotalCores))
+	}
+
+	if systemData.CPU.TotalThreads > 0 {
+		inv.Labels["elemental.cattle.io/CpuTotalThreads"] = strconv.Itoa(int(systemData.CPU.TotalThreads))
+	}
 
 	// This should never happen but just in case
 	if len(systemData.CPU.Processors) > 0 {


### PR DESCRIPTION
If run on aarch64 there is no info yet from ghw regarding the cpu threads/cores, so we end up with a useless label with zero values.

This patch makes it so its not stored if the value is zero, as youo cant have 0 cores in a cpu

Fixes #320 

Signed-off-by: Itxaka <igarcia@suse.com>