### PR TITLE
Replace action engineerd/setup-kind

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -96,10 +96,15 @@ jobs:
           key: ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-test-go-${{ hashFiles('**/go.sum') }}
-      - uses: engineerd/setup-kind@v0.5.0
+      - name: Install KinD
+        uses: jaxxstorm/action-install-gh-release@v1.9.0
         with:
-          version: "v0.16.0"
-          skipClusterCreation: "true"
+          repo: kubernetes-sigs/kind
+          tag: v0.16.0
+          extension-matching: disable
+          rename-to: kind
+          chmod: 0755
+          cache: enable
       - name: e2e tests
         run: make e2e-tests
       - name: Archive artifacts


### PR DESCRIPTION
Since node16 actions are being deprecated and no action seems to be taken.

This commit uses the jaxxstorm/action-install-gh-release action to install the kind binaries instead.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>