### PR TITLE
operator: add support to old register clients

### DIFF
--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -341,10 +341,6 @@ func (i *InventoryServer) handleGet(conn *websocket.Conn, protoVersion register.
 
 	logrus.Debug("Elemental cloud config sent")
 
-	if protoVersion == register.MsgUndefined {
-		logrus.Warn("Detected old elemental-register client: cloud-config data may not be applied correctly")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The CloudConfig structure was a serialized interface map: if an old client is detected, convert back to that legacy type.

Fixes #325 