### PR TITLE
operator: always use software UUID as default machine name

### DIFF
--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -138,7 +138,6 @@ func TestInitNewInventory(t *testing.T) {
 					},
 				},
 			},
-			expectedName: "m-${System Information/UUID}",
 		},
 		{
 			config: &elementalv1.Config{
@@ -150,8 +149,7 @@ func TestInitNewInventory(t *testing.T) {
 			},
 		},
 		{
-			config:       nil,
-			expectedName: "m-${System Information/UUID}",
+			config: nil,
 		},
 	}
 
@@ -166,7 +164,7 @@ func TestInitNewInventory(t *testing.T) {
 		inventory := &elementalv1.MachineInventory{}
 		initInventory(inventory, registration)
 
-		if test.config != nil && test.config.Elemental.Registration.NoSMBIOS {
+		if test.initName == "" {
 			assert.Check(t, mUUID.Match([]byte(inventory.Name)), inventory.Name+" is not UUID based")
 		} else {
 			assert.Equal(t, inventory.Name, test.expectedName)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -152,11 +152,7 @@ func initInventory(inventory *elementalv1.MachineInventory, registration *elemen
 	}
 	inventory.Name = registration.Spec.MachineName
 	if inventory.Name == "" {
-		if registration.Spec.Config.Elemental.Registration.NoSMBIOS {
-			inventory.Name = namePrefix + uuid.NewString()
-		} else {
-			inventory.Name = namePrefix + "${System Information/UUID}"
-		}
+		inventory.Name = namePrefix + uuid.NewString()
 	}
 	inventory.Namespace = registration.Namespace
 	inventory.Annotations = registration.Spec.MachineInventoryAnnotations


### PR DESCRIPTION
The default machine name is in the format: m-{UUID}.
The UUID is generated via software if SMBIOS data is disabled, otherwise the SMBIOS {System Information/UUID} is used.
Since some hardware vendors don't properly fill the UUID SMBIOS data, let always provide a machine name based on a software generated UUID, to ensure name uniqueness by default.

Fixes #339 