### PR TITLE
[Hackweek] add plain authentication method as an alternative to TPM

### DIFF
--- a/api/v1beta1/machineinventory_types.go
+++ b/api/v1beta1/machineinventory_types.go
@@ -33,6 +33,12 @@ type MachineInventorySpec struct {
 	// report their TPM hash by using the MachineRegister.
 	// +optional
 	TPMHash string `json:"tpmHash,omitempty"`
+	// MachineHash the hash of the identifier used by the host to identify
+	// to the operator. This is used when the host authenticates without TPM.
+	// Both the authentication method and the identifier used to derive the hash
+	// depend upon the MachineRegistration spec.config.elemental.registration.auth value.
+	// +optional
+	MachineHash string `json:"machineHash,omitempty"`
 }
 
 type MachineInventoryStatus struct {

--- a/api/v1beta1/machineregistration_types.go
+++ b/api/v1beta1/machineregistration_types.go
@@ -93,6 +93,7 @@ func (m MachineRegistration) GetClientRegistrationConfig(cacert string) *Config 
 				EmulateTPM:      mRegistration.EmulateTPM,
 				EmulatedTPMSeed: mRegistration.EmulatedTPMSeed,
 				NoSMBIOS:        mRegistration.NoSMBIOS,
+				Auth:            mRegistration.Auth,
 			},
 		},
 	}

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -58,6 +58,10 @@ type Registration struct {
 	EmulatedTPMSeed int64 `json:"emulated-tpm-seed,omitempty" yaml:"emulated-tpm-seed,omitempty" mapstructure:"emulated-tpm-seed"`
 	// +optional
 	NoSMBIOS bool `json:"no-smbios,omitempty" yaml:"no-smbios,omitempty" mapstructure:"no-smbios"`
+	// +optional
+	// +kubebuilder:validation:Enum=tpm;mac
+	// +kubebuilder:default:=tpm
+	Auth string `json:"auth,omitempty" yaml:"auth,omitempty" mapstructure:"auth"`
 }
 
 type SystemAgent struct {

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -36,6 +36,13 @@ spec:
             type: object
           spec:
             properties:
+              machineHash:
+                description: MachineHash the hash of the identifier used by the host
+                  to identify to the operator. This is used when the host authenticates
+                  without TPM. Both the authentication method and the identifier used
+                  to derive the hash depend upon the MachineRegistration spec.config.elemental.registration.auth
+                  value.
+                type: string
               tpmHash:
                 description: TPMHash the hash of the TPM EK public key. This is used
                   if you are using TPM2 to identifiy nodes.  You can obtain the TPM
@@ -683,6 +690,12 @@ spec:
                         type: object
                       registration:
                         properties:
+                          auth:
+                            default: tpm
+                            enum:
+                            - tpm
+                            - mac
+                            type: string
                           ca-cert:
                             type: string
                           emulate-tpm:

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -119,6 +119,7 @@ func main() {
 	cmd.Flags().BoolVar(&cfg.Elemental.Registration.EmulateTPM, "emulate-tpm", false, "Emulate /dev/tpm")
 	cmd.Flags().Int64Var(&cfg.Elemental.Registration.EmulatedTPMSeed, "emulated-tpm-seed", 1, "Seed for /dev/tpm emulation")
 	cmd.Flags().BoolVar(&cfg.Elemental.Registration.NoSMBIOS, "no-smbios", false, "Disable the use of dmidecode to get SMBIOS")
+	cmd.Flags().StringVar(&cfg.Elemental.Registration.Auth, "auth", "tpm", "Registration authentication method")
 	cmd.Flags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 	cmd.PersistentFlags().BoolP("version", "v", false, "print version and exit")
 	_ = viper.BindPFlag("version", cmd.PersistentFlags().Lookup("version"))

--- a/config/crd/bases/elemental.cattle.io_machineinventories.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineinventories.yaml
@@ -33,6 +33,13 @@ spec:
             type: object
           spec:
             properties:
+              machineHash:
+                description: MachineHash the hash of the identifier used by the host
+                  to identify to the operator. This is used when the host authenticates
+                  without TPM. Both the authentication method and the identifier used
+                  to derive the hash depend upon the MachineRegistration spec.config.elemental.registration.auth
+                  value.
+                type: string
               tpmHash:
                 description: TPMHash the hash of the TPM EK public key. This is used
                   if you are using TPM2 to identifiy nodes.  You can obtain the TPM

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -74,6 +74,12 @@ spec:
                         type: object
                       registration:
                         properties:
+                          auth:
+                            default: tpm
+                            enum:
+                            - tpm
+                            - mac
+                            type: string
                           ca-cert:
                             type: string
                           emulate-tpm:

--- a/pkg/plainauth/plainauth.go
+++ b/pkg/plainauth/plainauth.go
@@ -1,0 +1,121 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plainauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+)
+
+type AuthServer struct {
+	context.Context
+	client.Client
+}
+
+func New(ctx context.Context, cl client.Client) *AuthServer {
+	a := &AuthServer{
+		Context: ctx,
+		Client:  cl,
+	}
+
+	return a
+}
+
+func (a *AuthServer) Authenticate(conn *websocket.Conn, req *http.Request, regNamespace string) (*elementalv1.MachineInventory, bool, error) {
+	header := req.Header.Get("Authorization")
+	if !strings.HasPrefix(header, "Bearer PLAIN") {
+		logrus.Debugf("websocket connection missing PLAIN Authorization header from %s", req.RemoteAddr)
+		return nil, true, nil
+	}
+
+	logrus.Info("Authentication: PLAIN")
+	mac, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(header, "Bearer PLAIN"))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed Base64 decode: %w", err)
+	}
+	hashedMac := fmt.Sprintf("%x", sha256.Sum256(mac))
+
+	mInvetoryList := &elementalv1.MachineInventoryList{}
+	if err := a.List(a, mInvetoryList); err != nil {
+		return nil, false, fmt.Errorf("failed to get MachineInventories list: %w", err)
+	}
+
+	var mInventory *elementalv1.MachineInventory
+	for _, m := range mInvetoryList.Items {
+		if m.Spec.MachineHash == hashedMac {
+			// If we get two MachineInventory with the same MachineHash something went wrong
+			if mInventory != nil {
+				return nil, false, fmt.Errorf("failed to find inventory machine: Machine hash %s is present in both %s/%s and %s/%s",
+					hashedMac, mInventory.Namespace, mInventory.Name, m.Namespace, m.Name)
+			}
+			mInventory = (&m).DeepCopy()
+		}
+	}
+
+	if mInventory == nil {
+		mInventory = &elementalv1.MachineInventory{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: regNamespace,
+			},
+			Spec: elementalv1.MachineInventorySpec{
+				MachineHash: hashedMac,
+			},
+		}
+	}
+
+	return mInventory, false, nil
+}
+
+func GetHostMacAddr() ([]byte, error) {
+	ifList, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	hwAddr := []byte{}
+	for _, iface := range ifList {
+		if len(iface.HardwareAddr) == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			logrus.Errorf("Cannot get IP address for interface %s, skip it", iface.Name)
+			continue
+		}
+		if len(addrs) == 0 {
+			continue
+		}
+		hwAddr = iface.HardwareAddr
+	}
+
+	if len(hwAddr) == 0 {
+		return nil, fmt.Errorf("cannot retrieve MAC address from an active interface")
+	}
+
+	return hwAddr, nil
+}

--- a/pkg/plainauth/plainauth.go
+++ b/pkg/plainauth/plainauth.go
@@ -21,7 +21,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 
@@ -55,6 +54,7 @@ func (a *AuthServer) Authenticate(conn *websocket.Conn, req *http.Request, regNa
 	}
 
 	logrus.Info("Authentication: PLAIN")
+
 	mac, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(header, "Bearer PLAIN"))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed Base64 decode: %w", err)
@@ -90,32 +90,4 @@ func (a *AuthServer) Authenticate(conn *websocket.Conn, req *http.Request, regNa
 	}
 
 	return mInventory, false, nil
-}
-
-func GetHostMacAddr() ([]byte, error) {
-	ifList, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-	hwAddr := []byte{}
-	for _, iface := range ifList {
-		if len(iface.HardwareAddr) == 0 {
-			continue
-		}
-		addrs, err := iface.Addrs()
-		if err != nil {
-			logrus.Errorf("Cannot get IP address for interface %s, skip it", iface.Name)
-			continue
-		}
-		if len(addrs) == 0 {
-			continue
-		}
-		hwAddr = iface.HardwareAddr
-	}
-
-	if len(hwAddr) == 0 {
-		return nil, fmt.Errorf("cannot retrieve MAC address from an active interface")
-	}
-
-	return hwAddr, nil
 }

--- a/pkg/plainauth/register.go
+++ b/pkg/plainauth/register.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plainauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gorilla/websocket"
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/sirupsen/logrus"
+)
+
+type AuthClient struct {
+	macAddress []byte
+}
+
+func (auth *AuthClient) Init(reg elementalv1.Registration) error {
+	if auth.macAddress != nil {
+		logrus.Debugf("MAC Plan Authentication was already initialized: %x", auth.macAddress)
+		return nil
+	}
+
+	mac, err := GetHostMacAddr()
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("Plain authentication MAC:%x", mac)
+	auth.macAddress = mac
+	return nil
+}
+
+func (auth *AuthClient) GetName() string {
+	return "Plain (MAC-based)"
+}
+
+func (auth *AuthClient) GetToken() (string, error) {
+	if auth.macAddress == nil {
+		return "", fmt.Errorf("plainauth data is not initialized: have you called Init()?")
+	}
+	return "Bearer PLAIN" + base64.StdEncoding.EncodeToString(auth.macAddress), nil
+}
+
+func (auth *AuthClient) GetPubHash() (string, error) {
+	if auth.macAddress == nil {
+		return "", fmt.Errorf("plainauth data is not initialized: have you called Init()?")
+	}
+	pubHash := sha256.Sum256(auth.macAddress)
+	hashEncoded := fmt.Sprintf("%x", pubHash)
+	return hashEncoded, nil
+}
+
+func (auth *AuthClient) Authenticate(conn *websocket.Conn) error {
+	return nil
+}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rancher/elemental-operator/pkg/dmidecode"
 	"github.com/rancher/elemental-operator/pkg/hostinfo"
 	"github.com/rancher/elemental-operator/pkg/log"
+	"github.com/rancher/elemental-operator/pkg/plainauth"
 	"github.com/rancher/elemental-operator/pkg/tpm"
 )
 
@@ -51,6 +52,8 @@ func Register(reg elementalv1.Registration, caCert []byte) ([]byte, error) {
 	switch reg.Auth {
 	case "tpm":
 		auth = &tpm.AuthClient{}
+	case "mac":
+		auth = &plainauth.AuthClient{}
 	default:
 		return nil, fmt.Errorf("unsupported authentication: %s", reg.Auth)
 	}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -46,8 +46,14 @@ type authClient interface {
 }
 
 func Register(reg elementalv1.Registration, caCert []byte) ([]byte, error) {
-	// add here alternate auth methods that implement the authClient interface
-	var auth authClient = &tpm.AuthClient{}
+	var auth authClient
+
+	switch reg.Auth {
+	case "tpm":
+		auth = &tpm.AuthClient{}
+	default:
+		return nil, fmt.Errorf("unsupported authentication: %s", reg.Auth)
+	}
 
 	if err := auth.Init(reg); err != nil {
 		return nil, fmt.Errorf("init %s authentication: %w", auth.GetName(), err)

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -102,7 +102,7 @@ func (i *InventoryServer) apiRegistration(resp http.ResponseWriter, req *http.Re
 		}
 		return nil
 	}
-	log.Debugf("attestation completed")
+	log.Debugf("authentication completed")
 
 	if err = register.WriteMessage(conn, register.MsgReady, []byte{}); err != nil {
 		log.Errorf("cannot finalize the authentication process: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,7 @@ import (
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/log"
+	"github.com/rancher/elemental-operator/pkg/plainauth"
 	"github.com/rancher/elemental-operator/pkg/register"
 	"github.com/rancher/elemental-operator/pkg/tpm"
 )
@@ -52,6 +53,7 @@ func New(ctx context.Context, cl client.Client) *InventoryServer {
 		Context: ctx,
 		authenticators: []authenticator{
 			tpm.New(ctx, cl),
+			plainauth.New(ctx, cl),
 		},
 	}
 

--- a/pkg/tpm/auth_tpm.go
+++ b/pkg/tpm/auth_tpm.go
@@ -128,7 +128,7 @@ func writeRead(conn *websocket.Conn, input []byte) ([]byte, error) {
 func (a *AuthServer) Authenticate(conn *websocket.Conn, req *http.Request, registerNamespace string) (*elementalv1.MachineInventory, bool, error) {
 	header := req.Header.Get("Authorization")
 	if !strings.HasPrefix(header, "Bearer TPM") {
-		log.Debugf("websocket connection missing Authorization header from %s", req.RemoteAddr)
+		log.Debugf("websocket connection missing TPM Authorization header from %s", req.RemoteAddr)
 		return nil, true, nil
 	}
 

--- a/pkg/tpm/auth_tpm.go
+++ b/pkg/tpm/auth_tpm.go
@@ -128,9 +128,11 @@ func writeRead(conn *websocket.Conn, input []byte) ([]byte, error) {
 func (a *AuthServer) Authenticate(conn *websocket.Conn, req *http.Request, registerNamespace string) (*elementalv1.MachineInventory, bool, error) {
 	header := req.Header.Get("Authorization")
 	if !strings.HasPrefix(header, "Bearer TPM") {
-		log.Debugf("websocket connection missing TPM Authorization header from %s", req.RemoteAddr)
+		log.Debug("websocket connection: no TPM Authorization header")
 		return nil, true, nil
 	}
+
+	log.Info("Authentication: TPM")
 
 	ek, attestationData, err := gotpm.GetAttestationData(header)
 	if err != nil {


### PR DESCRIPTION
This PR reworks the TPM authentication part, mainly on the registration client side, in order to support different authentication methods during elemental registration.
The operator side authentication part was already demanded to an interface.
Now, we have isolated all the registration client authentication code to another interface, making extension easier.

This PR also add a new authentication method, were the client will use its own MAC address to generate an authentication token. The token is used by the operator to derive a MachineHash (which is the equivalent of the TPMHash) in the MachineInventory. There is no actual authentication, just identification based on the MAC address.

Ideally, we would like to use some form of authentication for subsequent registrations from the same machine (right now it will be enough to provide the right MAC-derived token).

While this is working, we may want to change the naming of the authentication methods (i.e., "mac"), and even the new keys added to the API: changes to the API should be careful considered. 
For this reason, and for further considerations found in the [hackweek project]( https://hackweek.opensuse.org/22/projects/elemental-operator-support-of-hosts-without-a-tpm-device) page let's keep this PR as a draft for now.

See the [hackweek project]( https://hackweek.opensuse.org/22/projects/elemental-operator-support-of-hosts-without-a-tpm-device) pagee for more information.
