### PR TITLE
register client: isolate TPM auth code

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -155,7 +155,7 @@ func run(config elementalv1.Config) {
 	}
 
 	for {
-		data, err = register.Register(registration.URL, caCert, !registration.NoSMBIOS, registration.EmulateTPM, registration.EmulatedTPMSeed)
+		data, err = register.Register(registration, caCert)
 		if err != nil {
 			logrus.Error("failed to register machine inventory: ", err)
 			time.Sleep(time.Second * 5)

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -47,10 +47,8 @@ type authClient interface {
 }
 
 func Register(reg elementalv1.Registration, caCert []byte) ([]byte, error) {
-	var auth authClient
-
 	// add here alternate auth methods that implement the authClient interface
-	auth = &tpm.AuthClient{}
+	var auth authClient = &tpm.AuthClient{}
 
 	if err := auth.Init(reg); err != nil {
 		return nil, fmt.Errorf("init %s authentication: %w", auth.GetName(), err)

--- a/pkg/tpm/register.go
+++ b/pkg/tpm/register.go
@@ -17,8 +17,15 @@ limitations under the License.
 package tpm
 
 import (
+	"math/big"
+	"math/rand"
+	"strings"
+
 	"github.com/gorilla/websocket"
+	"github.com/jaypipes/ghw"
 	gotpm "github.com/rancher-sandbox/go-tpm"
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/sirupsen/logrus"
 )
 
 type AttestationChannel struct {
@@ -49,31 +56,35 @@ type AuthClient struct {
 	ak         []byte
 }
 
-func (auth *AuthClient) EmulateTPM(seed int64) {
-	auth.emulateTPM = true
-	auth.seed = seed
+func (auth *AuthClient) Init(reg elementalv1.Registration) error {
+	if reg.EmulateTPM {
+		emulatedSeed := reg.EmulatedTPMSeed
+		logrus.Info("Enable TPM emulation")
+		if emulatedSeed == -1 {
+			data, err := ghw.Product(ghw.WithDisableWarnings())
+			if err != nil {
+				emulatedSeed = rand.Int63()
+				logrus.Debugf("TPM emulation using random seed: %d", emulatedSeed)
+			} else {
+				uuid := strings.Replace(data.UUID, "-", "", -1)
+				var i big.Int
+				_, converted := i.SetString(uuid, 16)
+				if !converted {
+					emulatedSeed = rand.Int63()
+					logrus.Debugf("TPM emulation using random seed: %d", emulatedSeed)
+				} else {
+					emulatedSeed = i.Int64()
+					logrus.Debugf("TPM emulation using system UUID %s, resulting in seed: %d", uuid, emulatedSeed)
+				}
+			}
+		}
+		auth.emulateTPM = true
+		auth.seed = emulatedSeed
+	}
+	return nil
 }
 
-func (auth *AuthClient) GetAuthToken() (string, string, error) {
-	var opts []gotpm.Option
-	if auth.emulateTPM {
-		opts = append(opts, gotpm.Emulated)
-		opts = append(opts, gotpm.WithSeed(auth.seed))
-	}
-	token, akBytes, err := gotpm.GetAuthToken(opts...)
-	if err != nil {
-		return "", "", err
-	}
-	auth.ak = akBytes
-
-	hash, err := gotpm.GetPubHash(opts...)
-	if err != nil {
-		return "", "", err
-	}
-	return token, hash, nil
-}
-
-func (auth *AuthClient) Init(conn *websocket.Conn) error {
+func (auth *AuthClient) Authenticate(conn *websocket.Conn) error {
 	var opts []gotpm.Option
 	if auth.emulateTPM {
 		opts = append(opts, gotpm.Emulated)
@@ -81,4 +92,32 @@ func (auth *AuthClient) Init(conn *websocket.Conn) error {
 	}
 
 	return gotpm.Authenticate(auth.ak, &AttestationChannel{conn}, opts...)
+}
+
+func (auth *AuthClient) GetName() string {
+	return "TPM"
+}
+
+func (auth *AuthClient) GetToken() (string, error) {
+	var opts []gotpm.Option
+	if auth.emulateTPM {
+		opts = append(opts, gotpm.Emulated)
+		opts = append(opts, gotpm.WithSeed(auth.seed))
+	}
+	token, akBytes, err := gotpm.GetAuthToken(opts...)
+	if err != nil {
+		return "", err
+	}
+	auth.ak = akBytes
+
+	return token, nil
+}
+
+func (auth *AuthClient) GetPubHash() (string, error) {
+	var opts []gotpm.Option
+	if auth.emulateTPM {
+		opts = append(opts, gotpm.Emulated)
+		opts = append(opts, gotpm.WithSeed(auth.seed))
+	}
+	return gotpm.GetPubHash(opts...)
 }


### PR DESCRIPTION
The register client code is tightly coupled with TPM attestation.
While this is not a problem right now as we just support authentication through TPM, it may be good to better separate TPM attestation from the registration process itself for two reasons:
 - better code readability
 - support of alternative authentication methods
(note that on the operator side the code is already structured to allow alternative authentication methods)

This commit introduces an interface with the required authentication methods: the TPM related code is now completely isolated in the interface implementation.

This PR is made up of commits from #345 which contains only the register client rework, dropping all the functional changes and extensions. So this PR:
- does NOT change any CRD
- does NOT introduce any new authentication method