### PR TITLE
operator: annotate remote host IP 

### DIFF
--- a/pkg/register/websocket.go
+++ b/pkg/register/websocket.go
@@ -38,7 +38,8 @@ const (
 	MsgSystemData
 	MsgConfig
 	MsgError
-	MsgLast = MsgError // MsgLast must point to the last message
+	MsgAnnotations
+	MsgLast = MsgAnnotations // MsgLast must point to the last message
 )
 
 func (mt MessageType) String() string {
@@ -61,6 +62,8 @@ func (mt MessageType) String() string {
 		return "Config"
 	case MsgError:
 		return "Error"
+	case MsgAnnotations:
+		return "Annotations"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
Allow the registering client to send the remote IP address: we will record it in MachineInventory annotations.
This fixes https://github.com/rancher/elemental/issues/629

This PR also adds a label with the MAC of the real (not virtual) interfaces that we already list as labels in the MachineInventory.

**This is still a PoC** for two main reasons:
- the register client is allowed to send arbitrary data that will be put in annotations.
We should either check the keys at the operator side or at least put a limit on the number of annotations a client can write otherwise we may expose the cluster to some DDOS attack.
- we have to review the data we provide and how we record it (labels/annotations): issue tracked in #349 

~Note: this PR is rebased on #346 to avoid the linter complaining about the Register function cyclomatic complexity~
(PR now rebased on main)