### PR TITLE
operator: let build-image API GET to return the image URL

### DIFF
--- a/pkg/server/api_buildimage_test.go
+++ b/pkg/server/api_buildimage_test.go
@@ -61,7 +61,7 @@ func TestApiBuildImage(t *testing.T) {
 			token:  "abcdef",
 			method: http.MethodGet,
 			url:    "/elemental/build-iso/abcdef",
-			body:   `{"status":"Not Started"}`,
+			body:   `{"status":"Not Started","url":""}`,
 			valid:  true,
 		},
 		{

--- a/pkg/server/registration_cache.go
+++ b/pkg/server/registration_cache.go
@@ -24,6 +24,7 @@ import (
 type registrationData struct {
 	buildImageURL    string
 	buildImageStatus string
+	downloadURL      string
 }
 type registrationCache struct {
 	*sync.Mutex
@@ -57,6 +58,20 @@ func (rc *registrationCache) setBuildImageStatus(token, status string) error {
 	}
 
 	reg.buildImageStatus = status
+	rc.registrations[token] = reg
+	return nil
+}
+
+func (rc *registrationCache) setDownloadURL(token, url string) error {
+	rc.Lock()
+	defer rc.Unlock()
+
+	reg, ok := rc.registrations[token]
+	if !ok {
+		return fmt.Errorf("item not found")
+	}
+
+	reg.downloadURL = url
 	rc.registrations[token] = reg
 	return nil
 }


### PR DESCRIPTION
Add the URL of the built image to the returned data from the build-image API.

Fixes #335 

Signed-off-by: Francesco Giudici <francesco.giudici@suse.com>