### PR TITLE
Turn MachineInventoryRef into LocalObjectReference

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -23,8 +23,8 @@ const (
 
 // Machine Registration conditions
 const (
-	// SuccefullyCreatedReason documents a machine registration object that was succefully created.
-	SuccefullyCreatedReason = "SuccefullyCreated"
+	// SuccessfullyCreatedReason documents a machine registration object that was successfully created.
+	SuccessfullyCreatedReason = "SuccessfullyCreated"
 
 	// MissingTokenOrServerURLReason documents a machine registration object missing rancher server url or failed token generation.
 	MissingTokenOrServerURLReason = "MissingTokenOrServerURL"
@@ -35,8 +35,8 @@ const (
 
 // Machine Inventory conditions
 const (
-	// SuccefullyCreatedPlanReason documents that the secret owned by the machine inventory was succesfully created.
-	SuccefullyCreatedPlanReason = "SuccefullyCreatedPlan"
+	// SuccessfullyCreatedPlanReason documents that the secret owned by the machine inventory was successfully created.
+	SuccessfullyCreatedPlanReason = "SuccessfullyCreatedPlan"
 
 	// WaitingForPlanReason documents a machine inventory waiting for plan to applied.
 	WaitingForPlanReason = "WaitingForPlan"
@@ -44,8 +44,8 @@ const (
 	// PlanFailure documents failure of plan owned by the machine inventory object.
 	PlanFailureReason = "PlanFailure"
 
-	// PlanSuccefullyAppliedReason documents that plan owned by the machine inventory object was succefully applied.
-	PlanSuccefullyAppliedReason = "PlanSuccefullyApplied"
+	// PlanSuccessfullyAppliedReason documents that plan owned by the machine inventory object was successfully applied.
+	PlanSuccessfullyAppliedReason = "PlanSuccessfullyApplied"
 )
 
 // Machine Selector conditions
@@ -53,14 +53,14 @@ const (
 	// WaitingForInventoryReason documents that the machine selector is waiting for a matching machine inventory.
 	WaitingForInventoryReason = "WaitingForInventory"
 
-	// SuccefullyAdoptedInventoryReason documents that the machine selector succesfully adopted machine inventory.
-	SuccefullyAdoptedInventoryReason = "SuccefullyAdoptedInventory"
+	// SuccessfullyAdoptedInventoryReason documents that the machine selector successfully adopted machine inventory.
+	SuccessfullyAdoptedInventoryReason = "SuccessfullyAdoptedInventory"
 
 	// FailedToAdoptInventoryReason documents that the machine selector failed to adopt machine inventory.
 	FailedToAdoptInventoryReason = "FailedToAdoptInventory"
 
-	// SuccefullyUpdatedPlanReason documents that the machine selector succesfully updated secret plan with bootstrap.
-	SuccefullyUpdatedPlanReason = "SuccefullyUpdatedPlan"
+	// SuccessfullyUpdatedPlanReason documents that the machine selector successfully updated secret plan with bootstrap.
+	SuccessfullyUpdatedPlanReason = "SuccessfullyUpdatedPlan"
 
 	// FailedToUpdatePlanReason documents that the machine selector failed to update secret plan with bootstrap.
 	FailedToUpdatePlanReason = "FailedToUpdatePlan"

--- a/api/v1beta1/machineselector_types.go
+++ b/api/v1beta1/machineselector_types.go
@@ -54,7 +54,7 @@ type MachineInventorySelectorStatus struct {
 	BootstrapPlanChecksum string `json:"bootstrapPlanChecksum,omitempty"`
 	// MachineInventoryRef reference to the machine inventory that belongs to the selector.
 	// +optional
-	MachineInventoryRef *corev1.ObjectReference `json:"machineInventoryRef,omitempty"` // TODO: use LocalObjectReference
+	MachineInventoryRef *corev1.LocalObjectReference `json:"machineInventoryRef,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -300,7 +300,7 @@ func (in *MachineInventorySelectorStatus) DeepCopyInto(out *MachineInventorySele
 	}
 	if in.MachineInventoryRef != nil {
 		in, out := &in.MachineInventoryRef, &out.MachineInventoryRef
-		*out = new(corev1.ObjectReference)
+		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
 }

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -359,37 +359,9 @@ spec:
                 description: MachineInventoryRef reference to the machine inventory
                   that belongs to the selector.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
@@ -615,38 +587,9 @@ spec:
                         description: MachineInventoryRef reference to the machine
                           inventory that belongs to the selector.
                         properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/config/crd/bases/elemental.cattle.io_machineinventoryselectors.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineinventoryselectors.yaml
@@ -180,37 +180,9 @@ spec:
                 description: MachineInventoryRef reference to the machine inventory
                   that belongs to the selector.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic

--- a/config/crd/bases/elemental.cattle.io_machineinventoryselectortemplates.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineinventoryselectortemplates.yaml
@@ -208,38 +208,9 @@ spec:
                         description: MachineInventoryRef reference to the machine
                           inventory that belongs to the selector.
                         properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -123,7 +123,7 @@ func (r *MachineInventoryReconciler) reconcile(ctx context.Context, mInventory *
 	if err := r.createPlanSecret(ctx, mInventory); err != nil {
 		meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.ReadyCondition,
-			Reason:  elementalv1.SuccefullyCreatedPlanReason,
+			Reason:  elementalv1.SuccessfullyCreatedPlanReason,
 			Status:  metav1.ConditionFalse,
 			Message: err.Error(),
 		})
@@ -221,14 +221,14 @@ func (r *MachineInventoryReconciler) updateInventoryWithPlanStatus(ctx context.C
 
 	switch {
 	case appliedChecksum != "":
-		logger.V(5).Info("Plan succefully applied")
+		logger.V(5).Info("Plan successfully applied")
 		mInventory.Status.Plan.State = elementalv1.PlanApplied
 		mInventory.Status.Plan.Checksum = appliedChecksum
 		meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.ReadyCondition,
-			Reason:  elementalv1.PlanSuccefullyAppliedReason,
+			Reason:  elementalv1.PlanSuccessfullyAppliedReason,
 			Status:  metav1.ConditionTrue,
-			Message: "plan succefully applied",
+			Message: "plan successfully applied",
 		})
 		return nil
 	case failedChecksum != "":

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
-	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
-	"github.com/rancher/elemental-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -38,6 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/util"
 )
 
 // MachineInventoryReconciler reconciles a MachineInventory object.

--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -22,8 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
-	"github.com/rancher/elemental-operator/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +29,9 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/test"
 )
 
 var _ = Describe("reconcile machine inventory", func() {

--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -118,9 +118,9 @@ var _ = Describe("reconcile machine inventory", func() {
 		Expect(mInventory.Status.Conditions).To(HaveLen(1))
 
 		Expect(mInventory.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.PlanSuccefullyAppliedReason))
+		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.PlanSuccessfullyAppliedReason))
 		Expect(mInventory.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-		Expect(mInventory.Status.Conditions[0].Message).To(Equal("plan succefully applied"))
+		Expect(mInventory.Status.Conditions[0].Message).To(Equal("plan successfully applied"))
 	})
 })
 
@@ -196,9 +196,9 @@ var _ = Describe("createPlanSecret", func() {
 	It("should do nothing if ready condition is present", func() {
 		meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.ReadyCondition,
-			Reason:  elementalv1.PlanSuccefullyAppliedReason,
+			Reason:  elementalv1.PlanSuccessfullyAppliedReason,
 			Status:  metav1.ConditionTrue,
-			Message: "plan succefully applied",
+			Message: "plan successfully applied",
 		})
 		Expect(r.createPlanSecret(ctx, mInventory)).To(Succeed())
 	})
@@ -248,9 +248,9 @@ var _ = Describe("updateInventoryWithPlanStatus", func() {
 
 		Expect(mInventory.Status.Conditions).To(HaveLen(1))
 		Expect(mInventory.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.PlanSuccefullyAppliedReason))
+		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.PlanSuccessfullyAppliedReason))
 		Expect(mInventory.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-		Expect(mInventory.Status.Conditions[0].Message).To(Equal("plan succefully applied"))
+		Expect(mInventory.Status.Conditions[0].Message).To(Equal("plan successfully applied"))
 	})
 
 	It("should return error when plan failed to be applied", func() {

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -145,7 +145,7 @@ func (r *MachineRegistrationReconciler) reconcile(ctx context.Context, mRegistra
 
 	meta.SetStatusCondition(&mRegistration.Status.Conditions, metav1.Condition{
 		Type:   elementalv1.ReadyCondition,
-		Reason: elementalv1.SuccefullyCreatedReason,
+		Reason: elementalv1.SuccessfullyCreatedReason,
 		Status: metav1.ConditionTrue,
 	})
 

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
-	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
-	"github.com/rancher/elemental-operator/pkg/util"
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/wrangler/pkg/randomtoken"
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/util"
 )
 
 // MachineRegistrationReconciler reconciles a MachineRegistration object.

--- a/controllers/machineregistration_controller_test.go
+++ b/controllers/machineregistration_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("reconcile machine registration", func() {
 		Expect(mRegistration.Status.ServiceAccountRef.Namespace).To(Equal(mRegistration.Namespace))
 		Expect(mRegistration.Status.Conditions).To(HaveLen(1))
 		Expect(mRegistration.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(mRegistration.Status.Conditions[0].Reason).To(Equal(elementalv1.SuccefullyCreatedReason))
+		Expect(mRegistration.Status.Conditions[0].Reason).To(Equal(elementalv1.SuccessfullyCreatedReason))
 		Expect(mRegistration.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
 
 		objKey := types.NamespacedName{Namespace: mRegistration.Namespace, Name: mRegistration.Name}

--- a/controllers/machineregistration_controller_test.go
+++ b/controllers/machineregistration_controller_test.go
@@ -22,8 +22,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
-	"github.com/rancher/elemental-operator/pkg/test"
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -33,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/test"
 )
 
 var _ = Describe("reconcile machine registration", func() {

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -226,7 +226,7 @@ func (r *MachineInventorySelectorReconciler) findAndAdoptInventory(ctx context.C
 
 	meta.SetStatusCondition(&miSelector.Status.Conditions, metav1.Condition{
 		Type:   elementalv1.ReadyCondition,
-		Reason: elementalv1.SuccefullyAdoptedInventoryReason,
+		Reason: elementalv1.SuccessfullyAdoptedInventoryReason,
 		Status: metav1.ConditionFalse,
 	})
 
@@ -286,7 +286,7 @@ func (r *MachineInventorySelectorReconciler) updatePlanSecretWithBootstrap(ctx c
 
 	meta.SetStatusCondition(&miSelector.Status.Conditions, metav1.Condition{
 		Type:   elementalv1.ReadyCondition,
-		Reason: elementalv1.SuccefullyUpdatedPlanReason,
+		Reason: elementalv1.SuccessfullyUpdatedPlanReason,
 		Status: metav1.ConditionFalse,
 	})
 

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -220,9 +220,8 @@ func (r *MachineInventorySelectorReconciler) findAndAdoptInventory(ctx context.C
 		return fmt.Errorf("failed to patch machine inventory: %w", err)
 	}
 
-	miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-		Name:      mInventory.Name,
-		Namespace: mInventory.Namespace,
+	miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+		Name: mInventory.Name,
 	}
 
 	meta.SetStatusCondition(&miSelector.Status.Conditions, metav1.Condition{
@@ -249,7 +248,7 @@ func (r *MachineInventorySelectorReconciler) updatePlanSecretWithBootstrap(ctx c
 
 	mInventory := &elementalv1.MachineInventory{}
 	if err := r.Get(ctx, types.NamespacedName{
-		Namespace: miSelector.Status.MachineInventoryRef.Namespace,
+		Namespace: miSelector.Namespace,
 		Name:      miSelector.Status.MachineInventoryRef.Name,
 	},
 		mInventory,
@@ -463,7 +462,7 @@ func (r *MachineInventorySelectorReconciler) setInvetorySelectorAddresses(ctx co
 
 	mInventory := &elementalv1.MachineInventory{}
 	if err := r.Get(ctx, types.NamespacedName{
-		Namespace: miSelector.Status.MachineInventoryRef.Namespace,
+		Namespace: miSelector.Namespace,
 		Name:      miSelector.Status.MachineInventoryRef.Name,
 	},
 		mInventory,

--- a/controllers/machineselector_controller_test.go
+++ b/controllers/machineselector_controller_test.go
@@ -19,13 +19,14 @@ package controllers
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
-	"github.com/rancher/elemental-operator/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/test"
 )
 
 var _ = Describe("reconcile machine inventory selector", func() {
@@ -140,7 +141,6 @@ var _ = Describe("reconcile machine inventory selector", func() {
 
 		Expect(miSelector.Status.MachineInventoryRef).ToNot(BeNil())
 		Expect(miSelector.Status.MachineInventoryRef.Name).To(Equal(mInventory.Name))
-		Expect(miSelector.Status.MachineInventoryRef.Namespace).To(Equal(mInventory.Namespace))
 
 		Expect(miSelector.Status.Conditions).To(HaveLen(1))
 		Expect(miSelector.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
@@ -219,7 +219,6 @@ var _ = Describe("findAndAdoptInventory", func() {
 
 		Expect(miSelector.Status.MachineInventoryRef).ToNot(BeNil())
 		Expect(miSelector.Status.MachineInventoryRef.Name).To(Equal(mInventory.Name))
-		Expect(miSelector.Status.MachineInventoryRef.Namespace).To(Equal(mInventory.Namespace))
 
 		Expect(r.Get(ctx, types.NamespacedName{Name: mInventory.Name, Namespace: mInventory.Namespace}, mInventory)).To(Succeed())
 		Expect(mInventory.OwnerReferences).To(HaveLen(1))
@@ -246,9 +245,8 @@ var _ = Describe("findAndAdoptInventory", func() {
 	})
 
 	It("should do nothing is machine inventory refernce is already set", func() {
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Namespace: "test",
-			Name:      "test",
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: "test",
 		}
 
 		Expect(r.findAndAdoptInventory(ctx, miSelector)).To(Succeed())
@@ -347,9 +345,8 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 	It("do nothing if machine inventory plan not ready yet", func() {
 		Expect(r.Create(ctx, mInventory)).To(Succeed())
 
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Name:      mInventory.Name,
-			Namespace: mInventory.Namespace,
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: mInventory.Name,
 		}
 
 		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector)).To(Succeed())
@@ -367,9 +364,8 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 		}
 		Expect(r.Status().Update(ctx, mInventory)).To(Succeed())
 
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Name:      mInventory.Name,
-			Namespace: mInventory.Namespace,
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: mInventory.Name,
 		}
 
 		err := r.updatePlanSecretWithBootstrap(ctx, miSelector)
@@ -390,9 +386,8 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 		}
 		Expect(r.Status().Update(ctx, mInventory)).To(Succeed())
 
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Name:      mInventory.Name,
-			Namespace: mInventory.Namespace,
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: mInventory.Name,
 		}
 		err := r.updatePlanSecretWithBootstrap(ctx, miSelector)
 		Expect(err).To(HaveOccurred())
@@ -414,9 +409,8 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 		}
 		Expect(r.Status().Update(ctx, mInventory)).To(Succeed())
 
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Name:      mInventory.Name,
-			Namespace: mInventory.Namespace,
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: mInventory.Name,
 		}
 		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector)).To(Succeed())
 
@@ -573,9 +567,8 @@ var _ = Describe("setInvetorySelectorAddresses", func() {
 	})
 
 	It("should return error if machine inventory is missing", func() {
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Name:      mInventory.Name,
-			Namespace: mInventory.Namespace,
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: mInventory.Name,
 		}
 
 		err := r.setInvetorySelectorAddresses(ctx, miSelector)
@@ -584,9 +577,8 @@ var _ = Describe("setInvetorySelectorAddresses", func() {
 	})
 
 	It("should succesfully set adresses", func() {
-		miSelector.Status.MachineInventoryRef = &corev1.ObjectReference{
-			Name:      mInventory.Name,
-			Namespace: mInventory.Namespace,
+		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
+			Name: mInventory.Name,
 		}
 
 		mInventory.Labels = map[string]string{

--- a/controllers/machineselector_controller_test.go
+++ b/controllers/machineselector_controller_test.go
@@ -204,7 +204,7 @@ var _ = Describe("findAndAdoptInventory", func() {
 		Expect(test.CleanupAndWait(ctx, cl, miSelector, mInventory)).To(Succeed())
 	})
 
-	It("succefully adopt matching machine inventory", func() {
+	It("successfully adopt matching machine inventory", func() {
 		mInventory.Labels = map[string]string{
 			"location": "testregion",
 		}
@@ -214,7 +214,7 @@ var _ = Describe("findAndAdoptInventory", func() {
 
 		Expect(miSelector.Status.Conditions).To(HaveLen(1))
 		Expect(miSelector.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(miSelector.Status.Conditions[0].Reason).To(Equal(elementalv1.SuccefullyAdoptedInventoryReason))
+		Expect(miSelector.Status.Conditions[0].Reason).To(Equal(elementalv1.SuccessfullyAdoptedInventoryReason))
 		Expect(miSelector.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 
 		Expect(miSelector.Status.MachineInventoryRef).ToNot(BeNil())
@@ -419,7 +419,7 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 
 		Expect(miSelector.Status.Conditions).To(HaveLen(1))
 		Expect(miSelector.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(miSelector.Status.Conditions[0].Reason).To(Equal(elementalv1.SuccefullyUpdatedPlanReason))
+		Expect(miSelector.Status.Conditions[0].Reason).To(Equal(elementalv1.SuccessfullyUpdatedPlanReason))
 		Expect(miSelector.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
 	})
 


### PR DESCRIPTION
Make the MachineInventorySelector reference to an owned
MachineInventory a LocalObjectReference, since a resource cannot
own another resource in a different namespace.

Fixes #180 

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>