### PR TITLE
Update actions/download-artifact to v3.0.2

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download chart
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: chart
           path: build


### PR DESCRIPTION
Fixes warnings about using `set-output`
https://github.com/actions/download-artifact/issues/185