### PR TITLE
build-image API: add build job with single pod lifecycle

### DIFF
--- a/chart/templates/cluster_role.yaml
+++ b/chart/templates/cluster_role.yaml
@@ -50,6 +50,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - machines

--- a/cmd/operator/operator/root.go
+++ b/cmd/operator/operator/root.go
@@ -52,6 +52,7 @@ import (
 // +kubebuilder:rbac:groups="",resources=events,verbs=patch;create
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;create;delete;list;watch
 // +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;create;delete;list;watch
 
 var (
 	scheme   = runtime.NewScheme()

--- a/config/rbac/bases/role.yaml
+++ b/config/rbac/bases/role.yaml
@@ -51,6 +51,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - machines

--- a/pkg/server/api_buildimage.go
+++ b/pkg/server/api_buildimage.go
@@ -25,11 +25,18 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 )
 
 const (
-	jobStatusStarted = "Started"
-	//	jobStatusCompleted  = "Completed"
+	jobStatusInit       = "Initialized"
+	jobStatusStarted    = "Started"
+	jobStatusCompleted  = "Completed"
 	jobStatusFailed     = "Failed"
 	jobStatusNotStarted = "Not Started"
 )
@@ -115,9 +122,9 @@ func (i *InventoryServer) apiBuildImagePostStart(resp http.ResponseWriter, req *
 	}
 
 	if reg, err := i.registrationCache.getRegistrationData(sanitizedJob.Token); err != nil {
-		if reg.buildImageStatus == jobStatusStarted {
+		if reg.buildImageStatus == jobStatusInit || reg.buildImageStatus == jobStatusStarted {
 			if reg.buildImageURL == sanitizedJob.URL {
-				logrus.Debugf("Same job already started, nothing to do")
+				logrus.Debugf("The build-image job has already started for token %s.", sanitizedJob.Token)
 
 				if err := json.NewEncoder(resp).Encode(sanitizedJob); err != nil {
 					errMsg := fmt.Errorf("cannot marshal build-image data: %w", err)
@@ -126,6 +133,7 @@ func (i *InventoryServer) apiBuildImagePostStart(resp http.ResponseWriter, req *
 				}
 				return nil
 			}
+			logrus.Debugf("Another build-image job is already running with token %s.", sanitizedJob.Token)
 			errMsg := fmt.Errorf("a build image task is already running for the MachineRegistration")
 			http.Error(resp, errMsg.Error(), http.StatusBadRequest)
 			return errMsg
@@ -134,13 +142,13 @@ func (i *InventoryServer) apiBuildImagePostStart(resp http.ResponseWriter, req *
 
 	i.registrationCache.setRegistrationData(sanitizedJob.Token, registrationData{
 		buildImageURL:    sanitizedJob.URL,
-		buildImageStatus: jobStatusStarted,
+		buildImageStatus: jobStatusInit,
 		downloadURL:      "",
 	})
 
 	logrus.Infof("New build-image job queued: seed image:'%s', reg token:'%s'", sanitizedJob.URL, sanitizedJob.Token)
 	// start the actual build job here
-	go i.draftDoBuildImage(sanitizedJob)
+	go i.doBuildImage(sanitizedJob)
 
 	if err := json.NewEncoder(resp).Encode(sanitizedJob); err != nil {
 		errMsg := fmt.Errorf("cannot marshal build-image data: %w", err)
@@ -150,23 +158,177 @@ func (i *InventoryServer) apiBuildImagePostStart(resp http.ResponseWriter, req *
 	return nil
 }
 
-func (i *InventoryServer) draftDoBuildImage(job buildImageJob) {
-	// This should spawn a pod that will:
-	// - download the base image (job.Url)
-	// - retrieve the registration YAML from the registrationToken (job.Token)
-	// - generate the seed image (base image + registration yaml)
-	// - return the seed image (url? shared volume?)
-	// Here we should just update the status then.
-	// For now, it will always fail.
-	logrus.Infof("build-image for token %s failed (build job not supported yet).", job.Token)
-	// let's add a small waiting time before reporting the job failure. We need this till we don't implement
-	// the actual build job to let the tests check that the build job is marked as started (otherwise this empty
-	// job may update the status to Failed before the test is able to check for the Started state).
-	time.Sleep(5 * time.Millisecond)
+func (i *InventoryServer) doBuildImage(job buildImageJob) {
+	// doBuildImage() spawns a pod that:
+	// - downloads the base image (job.Url)
+	// - retrieves the registration YAML from the registrationToken (job.Token)
+	// - generates the elemental image (seed image + registration yaml)
+	// - returns the elemental image (url)
+
+	const podName = "build-img"
+	const podNamespace = "cattle-elemental-system"
+
+	regURL, err := i.getRegistrationURL(job.Token)
+	if err != nil {
+		i.setFailedStatus(job.Token, err)
+		return
+	}
+
+	pod := buildImagePod(podName, podNamespace, job.URL, regURL)
+	if err := i.Create(i, pod); err != nil {
+		i.setFailedStatus(job.Token, fmt.Errorf("Failed to create build-image pod: %s.", err.Error()))
+		return
+	}
+
+	logrus.Infof("build image for token %s started.", job.Token)
 	if err := i.registrationCache.setDownloadURL(job.Token, ""); err != nil {
 		logrus.Errorf("Cannot update build-image download URL for job with token %s: %s", job.Token, err.Error())
 	}
-	if err := i.registrationCache.setBuildImageStatus(job.Token, jobStatusFailed); err != nil {
+	if err := i.registrationCache.setBuildImageStatus(job.Token, jobStatusStarted); err != nil {
 		logrus.Errorf("Cannot update build-image status for job with token %s: %s", job.Token, err.Error())
 	}
+
+	// TODO: create a Service to expose the built ISO and set properly the download URL
+
+	// TODO: use a watcher and have a timeout
+	// TODO: delete the pod on failure
+	failedCunter := 12
+	watchPod := &corev1.Pod{}
+	for {
+		failedCunter--
+		if err := i.Get(i, client.ObjectKey{Name: podName, Namespace: podNamespace}, watchPod); err != nil {
+			if failedCunter == 0 {
+				logrus.Errorf("Cannot check %s pod status.", podName)
+				i.setBuildStatus(job.Token, jobStatusFailed)
+				return
+			}
+		}
+		switch watchPod.Status.Phase {
+		case corev1.PodRunning:
+			i.setBuildStatus(job.Token, jobStatusCompleted)
+			return
+		case corev1.PodFailed:
+			i.setBuildStatus(job.Token, jobStatusFailed)
+			return
+		}
+
+		if failedCunter == 0 {
+			logrus.Errorf("POD %s timed out.", podName)
+			i.setBuildStatus(job.Token, jobStatusFailed)
+			return
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (i *InventoryServer) setBuildStatus(token string, status string) {
+	if err := i.registrationCache.setBuildImageStatus(token, status); err != nil {
+		logrus.Errorf("Cannot update build-image status for job with token %s: %s.", token, err.Error())
+	}
+}
+
+func (i *InventoryServer) setFailedStatus(token string, err error) {
+	logrus.Errorf("Failed to build img %s: %s.", token, err.Error())
+	i.setBuildStatus(token, jobStatusFailed)
+}
+
+func (i *InventoryServer) getRegistrationURL(token string) (string, error) {
+	mRegistrationList := &elementalv1.MachineRegistrationList{}
+
+	if err := i.List(i, mRegistrationList); err != nil {
+		return "", fmt.Errorf("cannot retrieve machine registration list: %w", err)
+	}
+	regURL := ""
+	for _, m := range mRegistrationList.Items {
+		if m.Status.RegistrationToken == token {
+			regURL = m.Status.RegistrationURL
+			break
+		}
+	}
+
+	if regURL == "" {
+		return "", fmt.Errorf("cannot find machine registration with token %s", token)
+	}
+
+	return regURL, nil
+}
+
+func buildImagePod(name, namespace, seedImgURL, regURL string) *corev1.Pod {
+	const buildImage = "registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-builder-image/5.3:latest"
+	// TODO: find a better serveImage
+	const serveImage = "quay.io/fgiudici/busybox:latest"
+	const volLim = 4 * 1024 * 1024 * 1024 // 4 GiB
+	const volRes = 2 * 1024 * 1024 * 1024 // 2 GiB
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"app.kubernetes.io/name": name},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name:  "build",
+					Image: buildImage,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceEphemeralStorage: *resource.NewQuantity(volLim, resource.BinarySI),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceEphemeralStorage: *resource.NewQuantity(volRes, resource.BinarySI),
+						},
+					},
+					Command: []string{"/bin/bash", "-c"},
+					Args: []string{
+						fmt.Sprintf("%s; %s; %s",
+							fmt.Sprintf("curl -Lo base.img %s", seedImgURL),
+							fmt.Sprintf("curl -ko reg.yaml %s", regURL),
+							"xorriso -indev base.img -outdev /iso/elemental.iso -map reg.yaml /reg.yaml -boot_image any replay"),
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "iso-storage",
+							MountPath: "/iso",
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "serve",
+					Image:   serveImage,
+					Command: []string{"/bin/sh", "-c"},
+					Args: []string{
+						"busybox httpd -f -v -p 80",
+					},
+					WorkingDir: "/iso",
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http-img",
+							ContainerPort: 80,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "iso-storage",
+							MountPath: "/iso",
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+			Volumes: []corev1.Volume{
+				{
+					Name: "iso-storage",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: resource.NewQuantity(volLim, resource.BinarySI),
+						},
+					},
+				},
+			},
+		},
+	}
+	return pod
 }

--- a/pkg/server/api_buildimage.go
+++ b/pkg/server/api_buildimage.go
@@ -257,7 +257,6 @@ func (i *InventoryServer) doBuildImage(job buildImageJob) {
 			if failedCounter == 0 {
 				logrus.Errorf("build-image: cannot check %s pod status.", buildImgResName)
 				i.setBuildStatus(job.Token, jobStatusFailed)
-				i.deleteBuildImagePodService(buildImgResName, buildImgResNamespace)
 				return
 			}
 		}
@@ -279,14 +278,12 @@ func (i *InventoryServer) doBuildImage(job buildImageJob) {
 		case corev1.PodFailed:
 			logrus.Infof("build-image: job %s: Failed.", job.Token)
 			i.setBuildStatus(job.Token, jobStatusFailed)
-			i.deleteBuildImagePodService(buildImgResName, buildImgResNamespace)
 			return
 		}
 
 		if failedCounter == 0 {
 			logrus.Errorf("build-image: job %s timed out.", job.Token)
 			i.setBuildStatus(job.Token, jobStatusFailed)
-			i.deleteBuildImagePodService(buildImgResName, buildImgResNamespace)
 			return
 		}
 		time.Sleep(5 * time.Second)

--- a/pkg/server/api_buildimage.go
+++ b/pkg/server/api_buildimage.go
@@ -100,9 +100,10 @@ func (i *InventoryServer) apiBuildImageGetStatus(resp http.ResponseWriter, req *
 }
 
 func sanitizeBuildImageJob(job buildImageJob) buildImageJob {
-	job.Token = sanitizeUserInput(job.Token)
-	job.URL = sanitizeUserInput(job.URL)
-	return job
+	sanitizedJob := buildImageJob{}
+	sanitizedJob.Token = sanitizeUserInput(job.Token)
+	sanitizedJob.URL = sanitizeUserInput(job.URL)
+	return sanitizedJob
 }
 
 func (i *InventoryServer) apiBuildImagePostStart(resp http.ResponseWriter, req *http.Request) error {

--- a/pkg/server/api_buildimage.go
+++ b/pkg/server/api_buildimage.go
@@ -249,7 +249,7 @@ func (i *InventoryServer) doBuildImage(job buildImageJob) {
 	}
 
 	// TODO: use a watcher and have a timeout
-	failedCounter = 15
+	failedCounter = 30
 	watchPod := &corev1.Pod{}
 	for {
 		failedCounter--
@@ -286,7 +286,7 @@ func (i *InventoryServer) doBuildImage(job buildImageJob) {
 			i.setBuildStatus(job.Token, jobStatusFailed)
 			return
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 }
 

--- a/pkg/server/registration_cache.go
+++ b/pkg/server/registration_cache.go
@@ -31,6 +31,19 @@ type registrationCache struct {
 	registrations map[string]registrationData
 }
 
+func (rc *registrationCache) getRegistrationKeys() []string {
+	rc.Lock()
+	defer rc.Unlock()
+
+	regList := make([]string, len(rc.registrations))
+
+	i := 0
+	for key := range rc.registrations {
+		regList[i] = key
+	}
+	return regList
+}
+
 func (rc *registrationCache) getRegistrationData(token string) (registrationData, error) {
 	rc.Lock()
 	defer rc.Unlock()
@@ -46,6 +59,17 @@ func (rc *registrationCache) setRegistrationData(token string, data registration
 	defer rc.Unlock()
 
 	rc.registrations[token] = data
+}
+
+func (rc *registrationCache) getBuildImageStatus(token string) (string, error) {
+	rc.Lock()
+	defer rc.Unlock()
+
+	reg, ok := rc.registrations[token]
+	if !ok {
+		return "", fmt.Errorf("item not found")
+	}
+	return reg.buildImageStatus, nil
 }
 
 func (rc *registrationCache) setBuildImageStatus(token, status string) error {


### PR DESCRIPTION
This PR adds the actual build of the elemental image in the build-image API.
This is the initial implementation, there are few things that should be improved. A couple:
- review and improve the lifecycle management of the Pod
- switch the container image used to publish the elemental ISO for download

Fixes https://github.com/rancher/elemental-operator/issues/355
Fixes https://github.com/rancher/elemental-operator/issues/356