### PR TITLE
operator: labels minor improvements

### DIFF
--- a/pkg/hostinfo/hostinfo.go
+++ b/pkg/hostinfo/hostinfo.go
@@ -55,7 +55,11 @@ type HostInfo struct {
 
 // Host returns a pointer to a HostInfo struct that contains fields with
 // information about the host system's CPU, memory, network devices, etc
-func Host(opts ...*ghw.WithOption) (*HostInfo, error) {
+func Host() (*HostInfo, error) {
+	return host(ghw.WithDisableWarnings())
+}
+
+func host(opts ...*ghw.WithOption) (*HostInfo, error) {
 	ctx := context.New(opts...)
 
 	memInfo, err := memory.New(opts...)

--- a/pkg/hostinfo/hostinfo.go
+++ b/pkg/hostinfo/hostinfo.go
@@ -122,6 +122,7 @@ func FillData(data []byte) (map[string]interface{}, error) {
 	memory := map[string]interface{}{}
 	if systemData.Memory != nil {
 		memory["Total Physical Bytes"] = strconv.Itoa(int(systemData.Memory.TotalPhysicalBytes))
+		memory["Total Usable Bytes"] = strconv.Itoa(int(systemData.Memory.TotalUsableBytes))
 	}
 
 	// Both checks below are due to ghw not detecting aarch64 cores/threads properly, so it ends up in a label
@@ -135,7 +136,6 @@ func FillData(data []byte) (map[string]interface{}, error) {
 		if systemData.CPU.TotalThreads > 0 {
 			cpu["Total Threads"] = strconv.Itoa(int(systemData.CPU.TotalThreads))
 		}
-
 		// This should never happen but just in case
 		if len(systemData.CPU.Processors) > 0 {
 			// Model still looks weird, maybe there is a way of getting it differently as we need to sanitize a lot of data in there?
@@ -143,7 +143,7 @@ func FillData(data []byte) (map[string]interface{}, error) {
 			// "Intel-R-Core-TM-i7-7700K-CPU-4-20GHz"
 			cpu["Model"] = systemData.CPU.Processors[0].Model
 			cpu["Vendor"] = systemData.CPU.Processors[0].Vendor
-			// Capabilities available here at systemData.CPU.Processors[X].Capabilities
+			cpu["Capabilities"] = systemData.CPU.Processors[0].Capabilities
 		}
 	}
 
@@ -159,8 +159,9 @@ func FillData(data []byte) (map[string]interface{}, error) {
 		network["Number Interfaces"] = strconv.Itoa(len(systemData.Network.NICs))
 		for _, iface := range systemData.Network.NICs {
 			network[iface.Name] = map[string]interface{}{
-				"Name":      iface.Name,
-				"IsVirtual": strconv.FormatBool(iface.IsVirtual),
+				"Name":       iface.Name,
+				"MacAddress": iface.MacAddress,
+				"IsVirtual":  strconv.FormatBool(iface.IsVirtual),
 				// Capabilities available here at iface.Capabilities
 				// interesting to store anything in here or show it on the docs? Difficult to use it afterwards as its a list...
 			}

--- a/pkg/hostinfo/hostinfo.go
+++ b/pkg/hostinfo/hostinfo.go
@@ -18,9 +18,7 @@ package hostinfo
 
 import (
 	"encoding/json"
-	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/baseboard"
@@ -143,8 +141,8 @@ func FillData(data []byte) (map[string]interface{}, error) {
 			// Model still looks weird, maybe there is a way of getting it differently as we need to sanitize a lot of data in there?
 			// Currently, something like "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz" ends up being:
 			// "Intel-R-Core-TM-i7-7700K-CPU-4-20GHz"
-			cpu["Model"] = sanitizeString(systemData.CPU.Processors[0].Model)
-			cpu["Vendor"] = sanitizeString(systemData.CPU.Processors[0].Vendor)
+			cpu["Model"] = systemData.CPU.Processors[0].Model
+			cpu["Vendor"] = systemData.CPU.Processors[0].Vendor
 			// Capabilities available here at systemData.CPU.Processors[X].Capabilities
 		}
 	}
@@ -152,8 +150,8 @@ func FillData(data []byte) (map[string]interface{}, error) {
 	gpu := map[string]interface{}{}
 	// This could happen so always check.
 	if systemData.GPU != nil && len(systemData.GPU.GraphicsCards) > 0 && systemData.GPU.GraphicsCards[0].DeviceInfo != nil {
-		gpu["Model"] = sanitizeString(systemData.GPU.GraphicsCards[0].DeviceInfo.Product.Name)
-		gpu["Vendor"] = sanitizeString(systemData.GPU.GraphicsCards[0].DeviceInfo.Vendor.Name)
+		gpu["Model"] = systemData.GPU.GraphicsCards[0].DeviceInfo.Product.Name
+		gpu["Vendor"] = systemData.GPU.GraphicsCards[0].DeviceInfo.Vendor.Name
 	}
 
 	network := map[string]interface{}{}
@@ -201,17 +199,4 @@ func FillData(data []byte) (map[string]interface{}, error) {
 	// systemData.Topology -> CPU/memory and cache topology. No idea if useful.
 
 	return labels, nil
-}
-
-// sanitizeString will sanitize a given string by:
-// replacing all invalid chars as set on the sanitize regex by dashes
-// removing any double dashes resulted from the above method
-// removing prefix+suffix if they are a dash
-func sanitizeString(s string) string {
-	sanitize := regexp.MustCompile("[^0-9a-zA-Z_]")
-	doubleDash := regexp.MustCompile("--+")
-
-	s1 := sanitize.ReplaceAllString(s, "-")
-	s2 := doubleDash.ReplaceAllString(s1, "-")
-	return strings.TrimSuffix(strings.TrimPrefix(s2, "-"), "-")
 }

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/jaypipes/ghw"
 	"github.com/pkg/errors"
 	"github.com/sanity-io/litter"
 	"github.com/sirupsen/logrus"
@@ -226,7 +225,7 @@ func sendSMBIOSData(conn *websocket.Conn) error {
 }
 
 func sendSystemData(conn *websocket.Conn) error {
-	data, err := hostinfo.Host(ghw.WithDisableWarnings())
+	data, err := hostinfo.Host()
 	if err != nil {
 		return errors.Wrap(err, "failed to read system data")
 	}

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -262,8 +262,7 @@ func replaceStringData(data map[string]interface{}, name string) (string, error)
 		str = str[j+i+1:]
 	}
 
-	resultStr := sanitize.ReplaceAllString(result.String(), "-")
-	resultStr = doubleDash.ReplaceAllString(resultStr, "-")
+	resultStr := sanitizeString(result.String())
 	if !start.MatchString(resultStr) {
 		resultStr = "m" + resultStr
 	}
@@ -498,7 +497,7 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 func sanitizeString(s string) string {
 	s1 := sanitize.ReplaceAllString(s, "-")
 	s2 := doubleDash.ReplaceAllString(s1, "-")
-	return strings.TrimSuffix(strings.TrimPrefix(s2, "-"), "-")
+	return s2
 }
 
 func mergeInventoryLabels(inventory *elementalv1.MachineInventory, data []byte) error {


### PR DESCRIPTION
This PR isolates the ghw library by making it completely wrapped inside the hostinfo package.
It also adds a couple of template labels (low hanging fruit), in particular the MAC address of the network interfaces.