### PR TITLE
elemental-register: support registration with 1.0.x operators

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -179,6 +179,8 @@ func run(config elementalv1.Config) {
 			cloudConf, err := converter.CloudConfigFromLegacy(legacyConfig.CloudConfig)
 			if err != nil {
 				log.Errorf("failed converting legacy cloud-config: %s", err.Error())
+				time.Sleep(time.Second * 5)
+				continue
 			}
 			config.Elemental = legacyConfig.Elemental
 			config.CloudConfig = cloudConf

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/itchyny/gojq v0.12.8 // indirect
 	github.com/itchyny/timefmt-go v0.1.3 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/compress v1.15.14 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converter
+
+import (
+	"encoding/json"
+	"fmt"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// LegacyConfig is the struct used to pass registration data by legacy Elemental
+// operators and legacy register-clients
+type LegacyConfig struct {
+	Elemental   elementalv1.Elemental  `yaml:"elemental"`
+	CloudConfig map[string]interface{} `yaml:"cloud-config,omitempty"`
+}
+
+func CloudConfigToLegacy(cloudConf map[string]runtime.RawExtension) (map[string]interface{}, error) {
+	legacyCloudConf := make(map[string]interface{})
+	for cloudKey, cloudData := range cloudConf {
+		var data interface{}
+		if err := json.Unmarshal(cloudData.Raw, &data); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal '%s'['%s']: %w", cloudKey, cloudData.Raw, err)
+		}
+		legacyCloudConf[cloudKey] = data
+	}
+	return legacyCloudConf, nil
+}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -20,8 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	jsoniter "github.com/json-iterator/go"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 )
 
 // LegacyConfig is the struct used to pass registration data by legacy Elemental
@@ -46,7 +48,7 @@ func CloudConfigToLegacy(cloudConf map[string]runtime.RawExtension) (map[string]
 func CloudConfigFromLegacy(legacyConf map[string]interface{}) (map[string]runtime.RawExtension, error) {
 	cloudConf := make(map[string]runtime.RawExtension)
 	for cloudKey, cloudVal := range legacyConf {
-		jsonVal, err := encodeToJSON(cloudVal)
+		jsonVal, err := jsoniter.Marshal(cloudVal)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal '%s'['%+v']: %w", cloudKey, cloudVal, err)
 		}
@@ -54,20 +56,4 @@ func CloudConfigFromLegacy(legacyConf map[string]interface{}) (map[string]runtim
 		cloudConf[cloudKey] = extension
 	}
 	return cloudConf, nil
-}
-
-func encodeToJSON(val interface{}) ([]byte, error) {
-	if m, ok := val.(map[interface{}]interface{}); ok {
-		// Convert nested map to map[string]interface{}
-		m2 := make(map[string]interface{})
-		for k, v := range m {
-			k2, ok := k.(string)
-			if !ok {
-				return nil, fmt.Errorf("key is not a string: %v", k)
-			}
-			m2[k2] = v
-		}
-		val = m2
-	}
-	return json.Marshal(val)
 }

--- a/pkg/converter/converter_suite_test.go
+++ b/pkg/converter/converter_suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package converter
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConverter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Converter Suite")
+}

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package converter
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Convert to legacy configuration", func() {
+
+	Context("received nested cloud-config data as map[string]interface{}", func() {
+
+		cloudConfData := map[string]interface{}{
+			"users": map[string]interface{}{
+				"name":   "bar",
+				"passwd": "foo",
+				"groups": "users",
+				"ssh_authorized_keys": []interface{}{
+					"ssh-key qwertyuyio123456",
+				},
+			},
+			"runcmd": []interface{}{
+				"foo",
+			},
+		}
+
+		It("should convert to map[string]runtime.RawExtension and back to legacy map[string]interface{}", func() {
+
+			cloudConf, err := CloudConfigFromLegacy(cloudConfData)
+			Expect(err).ShouldNot(HaveOccurred())
+			cloudConfLegacy, err := CloudConfigToLegacy(cloudConf)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			for k, v := range cloudConfData {
+				val, ok := cloudConfLegacy[k]
+				Expect(ok).To(BeTrue(), "key '%s' is missing", k)
+				v1 := reflect.ValueOf(v)
+				v2 := reflect.ValueOf(val)
+				Expect(v1.Type()).To(Equal(v2.Type()), "key '%s' types differ: %s vs %s", k, v1.Type(), v2.Type())
+				Expect(reflect.DeepEqual(v, val)).To(BeTrue(), "key '%s' values differ\n%+v\n%+v", k, v, val)
+			}
+		})
+	})
+})

--- a/pkg/converter/converter_test.go
+++ b/pkg/converter/converter_test.go
@@ -26,14 +26,31 @@ import (
 var _ = Describe("Convert to legacy configuration", func() {
 
 	Context("received nested cloud-config data as map[string]interface{}", func() {
-
 		cloudConfData := map[string]interface{}{
-			"users": map[string]interface{}{
-				"name":   "bar",
-				"passwd": "foo",
-				"groups": "users",
-				"ssh_authorized_keys": []interface{}{
-					"ssh-key qwertyuyio123456",
+			"users": []interface{}{
+				map[interface{}]interface{}{
+					"name":   "bar",
+					"passwd": "foo",
+					"groups": "users",
+					"ssh_authorized_keys": []interface{}{
+						"ssh-key qwertyuyio123456",
+					},
+				},
+			},
+			"runcmd": []interface{}{
+				"foo",
+			},
+		}
+
+		expectedData := map[string]interface{}{
+			"users": []interface{}{
+				map[string]interface{}{
+					"name":   "bar",
+					"passwd": "foo",
+					"groups": "users",
+					"ssh_authorized_keys": []interface{}{
+						"ssh-key qwertyuyio123456",
+					},
 				},
 			},
 			"runcmd": []interface{}{
@@ -48,7 +65,7 @@ var _ = Describe("Convert to legacy configuration", func() {
 			cloudConfLegacy, err := CloudConfigToLegacy(cloudConf)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			for k, v := range cloudConfData {
+			for k, v := range expectedData {
 				val, ok := cloudConfLegacy[k]
 				Expect(ok).To(BeTrue(), "key '%s' is missing", k)
 				v1 := reflect.ValueOf(v)


### PR DESCRIPTION
This PR introduces support with 1.0.x operators by managing:
- 1.0.x operator tears down newer clients when starting the protocol negotiation
- conversion from the older cloud-config format ( map[string]interface{} vs map[string]runtime.RawExtension )

Fixes https://github.com/rancher/elemental/issues/694