### PR TITLE
Prevent MachineInventorySelector from being cached

### DIFF
--- a/cmd/operator/operator/root.go
+++ b/cmd/operator/operator/root.go
@@ -177,6 +177,7 @@ func operatorRun(config *rootConfig) {
 			&corev1.ConfigMap{},
 			&corev1.Secret{},
 			&elementalv1.ManagedOSVersion{},
+			&elementalv1.MachineInventorySelector{},
 		},
 		Port:                   config.webhookPort,
 		CertDir:                config.webhookCertDir,


### PR DESCRIPTION
In CI we face many reconcile loops of machineinventoryselector one after the other and it's logic is highly dependent on having up to date values from resources as it has an adoption logic for another resources everything needs to be in sync to prevent rerunning adoption logic more than once successfully (a single machineinventoryselector adopting two different inventories).

Fixes rancher/elemental#667