### PR TITLE
unit-tests: ensure resources cleanup

### DIFF
--- a/controllers/machineregistration_controller_test.go
+++ b/controllers/machineregistration_controller_test.go
@@ -39,19 +39,31 @@ var _ = Describe("reconcile machine registration", func() {
 	var r *MachineRegistrationReconciler
 	var mRegistration *elementalv1.MachineRegistration
 	var setting *managementv3.Setting
+	var role *rbacv1.Role
+	var roleBinding *rbacv1.RoleBinding
+	var sa *corev1.ServiceAccount
+	var secret *corev1.Secret
 
 	BeforeEach(func() {
 		r = &MachineRegistrationReconciler{
 			Client: cl,
 		}
 
-		mRegistration = &elementalv1.MachineRegistration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "default",
-			},
+		objKey := metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "default",
 		}
 
+		mRegistration = &elementalv1.MachineRegistration{ObjectMeta: objKey}
+		role = &rbacv1.Role{ObjectMeta: objKey}
+		roleBinding = &rbacv1.RoleBinding{ObjectMeta: objKey}
+		sa = &corev1.ServiceAccount{ObjectMeta: objKey}
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: mRegistration.Namespace,
+				Name:      mRegistration.Name + "-token",
+			},
+		}
 		setting = &managementv3.Setting{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "server-url",
@@ -65,7 +77,7 @@ var _ = Describe("reconcile machine registration", func() {
 	})
 
 	AfterEach(func() {
-		Expect(test.CleanupAndWait(ctx, cl, mRegistration, setting)).To(Succeed())
+		Expect(test.CleanupAndWait(ctx, cl, mRegistration, setting, role, roleBinding, sa, secret)).To(Succeed())
 	})
 
 	It("should reconcile machine registration object", func() {


### PR DESCRIPTION
this allows to fix sporadic issues with unit tests:

```
createRBACObjects
  should successfully create RBAC objects
  /home/fgiudici/go/src/github.com/rancher/elemental-operator/controllers/machineregistration_controller_test.go:202
1.6788283160593388e+09  INFO    Reconciling RBAC resources
1.6788283160594149e+09  INFO    Creating role
1.6788283160648215e+09  INFO    Creating service account
1.6788283160696208e+09  INFO    Creating token secret for the service
  account
1.6788283160727391e+09  INFO    Creating role binding
1.678828316076215e+09   INFO    Setting service account ref
------------------------------
• [FAILED] [0.090 seconds]
createRBACObjects
/home/fgiudici/go/src/github.com/rancher/elemental-operator/controllers/machineregistration_controller_test.go:158
  [It] should successfully create RBAC objects
  /home/fgiudici/go/src/github.com/rancher/elemental-operator/controllers/machineregistration_controller_test.go:202

  Begin Captured GinkgoWriter Output >>
    1.6788283160593388e+09      INFO    Reconciling RBAC resources
    1.6788283160594149e+09      INFO    Creating role
    1.6788283160648215e+09      INFO    Creating service account
    1.6788283160696208e+09      INFO    Creating token secret for the
      service account
    1.6788283160727391e+09      INFO    Creating role binding
    1.678828316076215e+09       INFO    Setting service account ref
  << End Captured GinkgoWriter Output

  Expected
      <types.UID>: dabb952e-aced-466f-9a98-555675dbd66f
  to equal
      <types.UID>: testuid
  In [It] at:
/home/fgiudici/go/src/github.com/rancher/elemental-operator/controllers/machineregistration_controller_test.go:212

  Full Stack Trace
    github.com/rancher/elemental-operator/controllers.glob..func6.3()
        /home/fgiudici/go/src/github.com/rancher/elemental-operator/controllers/machineregistration_controller_test.go:212
+0x8b3
```