### PR TITLE
operator: ensure elemental finalizers are removed if present

### DIFF
--- a/api/v1beta1/seedimage_type.go
+++ b/api/v1beta1/seedimage_type.go
@@ -21,10 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	SeedImageFinalizer = "seedimage.elemental.cattle.io"
-)
-
 type SeedImageSpec struct {
 	// BaseImg the base elemental image used to build the seed image.
 	// +optional

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -114,6 +115,11 @@ func (r *MachineInventoryReconciler) reconcile(ctx context.Context, mInventory *
 	logger := ctrl.LoggerFrom(ctx)
 
 	logger.Info("Reconciling machineinventory object")
+
+	if mInventory.GetDeletionTimestamp() != nil {
+		controllerutil.RemoveFinalizer(mInventory, elementalv1.MachineInventoryFinalizer)
+		return ctrl.Result{}, nil
+	}
 
 	if err := r.createPlanSecret(ctx, mInventory); err != nil {
 		meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -111,6 +112,11 @@ func (r *MachineRegistrationReconciler) reconcile(ctx context.Context, mRegistra
 	logger := ctrl.LoggerFrom(ctx)
 
 	logger.Info("Reconciling machineregistration object")
+
+	if mRegistration.GetDeletionTimestamp() != nil {
+		controllerutil.RemoveFinalizer(mRegistration, elementalv1.MachineRegistrationFinalizer)
+		return ctrl.Result{}, nil
+	}
 
 	if meta.IsStatusConditionTrue(mRegistration.Status.Conditions, elementalv1.ReadyCondition) {
 		logger.Info("Machine registration is ready, no need to reconcile it")


### PR DESCRIPTION
We have removed finalizers from MachineInventories and MachineRegistrations.
Still if we upgrade from older operator versions, we may inherit old resources with the finalizers set there. In this case, when the "old" resources get deleted, no one will remove the finalizers preventing their actual deletion.
Ensure the finalizers are cleaned up if there when the resource is deleted.

Fixes #391 