### PR TITLE
SeedImage: fix registration yaml name

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -360,7 +360,7 @@ func fillBuildImagePod(name, namespace, baseImg, regURL string) *corev1.Pod {
 						fmt.Sprintf("%s && %s && %s",
 							fmt.Sprintf("curl -Lo base.img %s", baseImg),
 							fmt.Sprintf("curl -ko reg.yaml %s", regURL),
-							"xorriso -indev base.img -outdev /iso/elemental.iso -map reg.yaml /reg.yaml -boot_image any replay"),
+							"xorriso -indev base.img -outdev /iso/elemental.iso -map reg.yaml /livecd-cloud-config.yaml -boot_image any replay"),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
 ... otherwise auto-install would not work:

```
rancher-7934:/system/oem # cat 99_elemental-register.yaml name: "Elemental operator bootstrap"
stages:
  network.after:
    # run only if on live cd and there is a config file
    - if: '[ -f /run/cos/live_mode ] && [ -f
      /run/initramfs/live/livecd-cloud-config.yaml ]'
      commands:
        - systemd-cat -t elemental elemental-register --debug /run/initramfs/live/
```