### PR TITLE
Fix adoption logic

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -35,8 +35,8 @@ const (
 
 // Machine Inventory conditions
 const (
-	// SuccessfullyCreatedPlanReason documents that the secret owned by the machine inventory was successfully created.
-	SuccessfullyCreatedPlanReason = "SuccessfullyCreatedPlan"
+	// PlanCreationFailureReason documents that the secret plan owned by the machine inventory could not be created
+	PlanCreationFailureReason = "PlanCreationFailureReason"
 
 	// WaitingForPlanReason documents a machine inventory waiting for plan to applied.
 	WaitingForPlanReason = "WaitingForPlan"
@@ -48,16 +48,27 @@ const (
 	PlanSuccessfullyAppliedReason = "PlanSuccessfullyApplied"
 )
 
+const (
+	// AdoptedCondition documents the state of a machine selector adopting the machine inventory
+	AdoptionReadyCondition = "AdoptionReady"
+
+	// WaitingToBeAdoptedReason documents that the machine inventory is waiting to be adopted
+	WaitingToBeAdoptedReason = "WaitingToBeAdopted"
+
+	// ValidatinAdoptionReason documents that the machine inventory is in the process of validating its owner has the appropriate status
+	ValidatingAdoptionReason = "ValidatingAdoption"
+
+	// SuccessfullyAdoptedReason documents that the machine inventory is successully adopted by a machine selector
+	SuccessfullyAdoptedReason = "SuccessfullyAdopted"
+
+	// AdoptionFailureReason documents that the machine inventory adoption process failed
+	AdoptionFailureReason = "AdoptionFailure"
+)
+
 // Machine Selector conditions
 const (
 	// WaitingForInventoryReason documents that the machine selector is waiting for a matching machine inventory.
 	WaitingForInventoryReason = "WaitingForInventory"
-
-	// SuccessfullyAdoptedInventoryReason documents that the machine selector successfully adopted machine inventory.
-	SuccessfullyAdoptedInventoryReason = "SuccessfullyAdoptedInventory"
-
-	// FailedToAdoptInventoryReason documents that the machine selector failed to adopt machine inventory.
-	FailedToAdoptInventoryReason = "FailedToAdoptInventory"
 
 	// SuccessfullyUpdatedPlanReason documents that the machine selector successfully updated secret plan with bootstrap.
 	SuccessfullyUpdatedPlanReason = "SuccessfullyUpdatedPlan"
@@ -65,11 +76,25 @@ const (
 	// FailedToUpdatePlanReason documents that the machine selector failed to update secret plan with bootstrap.
 	FailedToUpdatePlanReason = "FailedToUpdatePlan"
 
-	// SelectorReadyReason documents that the machine selector is ready.
-	SelectorReadyReason = "SelectorReady"
-
 	// FailedToSetAdressesReason documents that the machine selector controller failed to set adresses.
 	FailedToSetAdressesReason = "FailedToSetAdresses"
+
+	// SelectorReadyReason documents that the machine selector is ready.
+	SelectorReadyReason = "SelectorReady"
+)
+
+const (
+	// InventoryReady documents the state of the selector adopting an inventory
+	InventoryReadyCondition = "InventoryReady"
+
+	// WaitForInventoryCheckReason documents the selector is waiting for the inventory to validate the adoption
+	WaitForInventoryCheckReason = "WaitForInventoryCheck"
+
+	// SuccessfullyAdoptedInventoryReason documents that the machine selector successfully adopted machine inventory.
+	SuccessfullyAdoptedInventoryReason = "SuccessfullyAdoptedInventory"
+
+	// FailedToAdoptInventoryReason documents that the machine selector failed to adopt machine inventory.
+	FailedToAdoptInventoryReason = "FailedToAdoptInventory"
 )
 
 // Managed OS Version Channel conditions

--- a/cmd/operator/operator/root.go
+++ b/cmd/operator/operator/root.go
@@ -181,7 +181,6 @@ func operatorRun(config *rootConfig) {
 			&corev1.ConfigMap{},
 			&corev1.Secret{},
 			&elementalv1.ManagedOSVersion{},
-			&elementalv1.MachineInventorySelector{},
 		},
 		Port:                   config.webhookPort,
 		CertDir:                config.webhookCertDir,

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -165,10 +165,9 @@ func (r *MachineInventoryReconciler) createPlanSecret(ctx context.Context, mInve
 
 	readyCondition := meta.FindStatusCondition(mInventory.Status.Conditions, elementalv1.ReadyCondition)
 	if readyCondition != nil && readyCondition.Reason != elementalv1.PlanCreationFailureReason {
-		logger.Info("Skipping plan secret creation because ready condition is already set")
+		logger.V(log.DebugDepth).Info("Skipping plan secret creation because ready condition is already set")
 		return nil
 	}
-	logger.Info("Creating plan secret")
 
 	planSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -202,6 +201,7 @@ func (r *MachineInventoryReconciler) createPlanSecret(ctx context.Context, mInve
 		},
 	}
 
+	logger.Info("Plan secret created")
 	meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{
 		Type:    elementalv1.ReadyCondition,
 		Reason:  elementalv1.WaitingForPlanReason,
@@ -222,7 +222,7 @@ func (r *MachineInventoryReconciler) updateInventoryWithPlanStatus(ctx context.C
 		},
 	}
 
-	logger.Info("Attempting to set plan status")
+	logger.V(log.DebugDepth).Info("Attempting to set plan status")
 	if err := r.Get(ctx, types.NamespacedName{
 		Namespace: mInventory.Namespace,
 		Name:      mInventory.Name,
@@ -246,12 +246,12 @@ func (r *MachineInventoryReconciler) updateInventoryWithPlanStatus(ctx context.C
 		})
 		return nil
 	case failedChecksum != "":
-		logger.Info("Plan failed to be applied")
+		logger.V(log.DebugDepth).Info("Plan failed to be applied")
 		mInventory.Status.Plan.State = elementalv1.PlanFailed
 		mInventory.Status.Plan.Checksum = failedChecksum
 		return fmt.Errorf("failed to apply plan")
 	default:
-		logger.Info("Waiting for plan to be applied")
+		logger.V(log.DebugDepth).Info("Waiting for plan to be applied")
 		meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.ReadyCondition,
 			Reason:  elementalv1.WaitingForPlanReason,
@@ -322,7 +322,7 @@ func (r *MachineInventoryReconciler) updateInventoryWithAdoptionStatus(ctx conte
 		removeSelectorOwnerShip(mInventory)
 		return false, fmt.Errorf("Ownership mismatch, dropping selector ownership")
 	default:
-		logger.V(log.DebugDepth).Info("Successfully adopted")
+		logger.Info("Successfully adopted")
 		meta.SetStatusCondition(&mInventory.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.AdoptionReadyCondition,
 			Reason:  elementalv1.SuccessfullyAdoptedReason,

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -33,10 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/log"
@@ -59,13 +57,6 @@ func (r *MachineInventoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&elementalv1.MachineInventory{}).
 		Owns(&corev1.Secret{}).
-		Watches(
-			&source.Kind{
-				Type: &corev1.Secret{},
-			},
-			&handler.EnqueueRequestForOwner{
-				IsController: true,
-				OwnerType:    &elementalv1.MachineInventory{}}).
 		WithEventFilter(r.ignoreIncrementalStatusUpdate()).
 		Complete(r)
 }

--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -167,12 +167,12 @@ var _ = Describe("createPlanSecret", func() {
 		Expect(mInventory.Status.Plan.PlanSecretRef.Name).To(Equal(mInventory.Name))
 		Expect(mInventory.Status.Plan.PlanSecretRef.Namespace).To(Equal(mInventory.Namespace))
 
-		Expect(mInventory.Status.Conditions).To(HaveLen(1))
+		cond := meta.FindStatusCondition(mInventory.Status.Conditions, elementalv1.ReadyCondition)
+		Expect(cond).NotTo(BeNil())
 
-		Expect(mInventory.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.WaitingForPlanReason))
-		Expect(mInventory.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-		Expect(mInventory.Status.Conditions[0].Message).To(Equal("waiting for plan to be applied"))
+		Expect(cond.Reason).To(Equal(elementalv1.WaitingForPlanReason))
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Message).To(Equal("waiting for plan to be applied"))
 	})
 
 	It("shouldn't return error is secret already exists", func() {

--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -82,12 +82,12 @@ var _ = Describe("reconcile machine inventory", func() {
 			Namespace: mInventory.Namespace,
 		}, mInventory)).To(Succeed())
 
-		Expect(mInventory.Status.Conditions).To(HaveLen(1))
+		cond := meta.FindStatusCondition(mInventory.Status.Conditions, elementalv1.ReadyCondition)
+		Expect(cond).NotTo(BeNil())
 
-		Expect(mInventory.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.WaitingForPlanReason))
-		Expect(mInventory.Status.Conditions[0].Status).To(Equal(metav1.ConditionFalse))
-		Expect(mInventory.Status.Conditions[0].Message).To(Equal("waiting for plan to be applied"))
+		Expect(cond.Reason).To(Equal(elementalv1.WaitingForPlanReason))
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Message).To(Equal("waiting for plan to be applied"))
 	})
 
 	It("should reconcile machine inventory object when plan secret already exists", func() {
@@ -109,12 +109,12 @@ var _ = Describe("reconcile machine inventory", func() {
 		Expect(mInventory.Status.Plan.Checksum).To(Equal(string(planSecret.Data["applied-checksum"])))
 		Expect(mInventory.Status.Plan.State).To(Equal(elementalv1.PlanApplied))
 
-		Expect(mInventory.Status.Conditions).To(HaveLen(1))
+		cond := meta.FindStatusCondition(mInventory.Status.Conditions, elementalv1.ReadyCondition)
+		Expect(cond).NotTo(BeNil())
 
-		Expect(mInventory.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
-		Expect(mInventory.Status.Conditions[0].Reason).To(Equal(elementalv1.PlanSuccessfullyAppliedReason))
-		Expect(mInventory.Status.Conditions[0].Status).To(Equal(metav1.ConditionTrue))
-		Expect(mInventory.Status.Conditions[0].Message).To(Equal("plan successfully applied"))
+		Expect(cond.Reason).To(Equal(elementalv1.PlanSuccessfullyAppliedReason))
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Message).To(Equal("plan successfully applied"))
 	})
 })
 

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -151,7 +151,7 @@ func (r *MachineInventorySelectorReconciler) reconcile(ctx context.Context, miSe
 			Status:  metav1.ConditionFalse,
 			Message: err.Error(),
 		})
-		return ctrl.Result{}, fmt.Errorf("failed to set bootstrap plan: %w", err)
+		return ctrl.Result{}, fmt.Errorf("failed to set adoption status: %w", err)
 	}
 
 	if err := r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory); err != nil {

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -88,7 +88,9 @@ func (r *MachineInventorySelectorReconciler) Reconcile(ctx context.Context, req 
 		return reconcile.Result{}, fmt.Errorf("failed to get machine inventory selector object: %w", err)
 	}
 
-	patchBase := client.MergeFrom(machineInventorySelector.DeepCopy())
+	// Ensure we patch the latest version otherwise we could erratically
+	// overwrite the adopted reference when it was already set
+	patchBase := client.MergeFromWithOptions(machineInventorySelector.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	// We have to sanitize the conditions because old API definitions didn't have proper validation.
 	machineInventorySelector.Status.Conditions = util.RemoveInvalidConditions(machineInventorySelector.Status.Conditions)

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -259,7 +259,7 @@ func (r *MachineInventorySelectorReconciler) updateAdoptionStatus(ctx context.Co
 
 	inventoryReady := meta.FindStatusCondition(miSelector.Status.Conditions, elementalv1.InventoryReadyCondition)
 	if inventoryReady == nil {
-		return false, fmt.Errorf("Missing required InventoryReadyCondition it must be already set at this phase")
+		return false, fmt.Errorf("missing required InventoryReadyCondition it must be already set at this phase")
 	}
 	if inventoryReady.Status == metav1.ConditionTrue {
 		logger.V(log.DebugDepth).Info("Machine inventory is successfully adopted already")
@@ -288,10 +288,10 @@ func (r *MachineInventorySelectorReconciler) updateAdoptionStatus(ctx context.Co
 	switch {
 	case owner != nil && owner.Name != miSelector.Name:
 		miSelector.Status.MachineInventoryRef = nil
-		return false, fmt.Errorf("Machine inventory ownership mismatch detected, restart adoption")
+		return false, fmt.Errorf("machine inventory ownership mismatch detected, restart adoption")
 	case orphanInventory && now.After(deadLine):
 		miSelector.Status.MachineInventoryRef = nil
-		return false, fmt.Errorf("Machine inventory adoption validation timeout, restart adoption. Deadline was: %v", deadLine)
+		return false, fmt.Errorf("machine inventory adoption validation timeout, restart adoption. Deadline was: %v", deadLine)
 	case orphanInventory:
 		logger.V(log.DebugDepth).Info("Machine inventory adoption not completed")
 		meta.SetStatusCondition(&miSelector.Status.Conditions, metav1.Condition{
@@ -656,7 +656,7 @@ func (r *MachineInventorySelectorReconciler) MachineInventoryToSelector(o client
 	miSelectorList := &elementalv1.MachineInventorySelectorList{}
 	err := r.List(ctx, miSelectorList, client.InNamespace(mInventory.Namespace))
 	if err != nil {
-		logger.Error(err, "Failed to list machine inventories")
+		logger.Error(err, "failed to list machine inventories")
 		return result
 	}
 

--- a/controllers/machineselector_controller_test.go
+++ b/controllers/machineselector_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("findAndAdoptInventory", func() {
 		}
 		Expect(r.Create(ctx, mInventory)).To(Succeed())
 
-		Expect(r.findAndAdoptInventory(ctx, miSelector)).To(Succeed())
+		Expect(r.findAndAdoptInventory(ctx, miSelector, &elementalv1.MachineInventory{})).To(Succeed())
 
 		Expect(miSelector.Status.Conditions).To(HaveLen(1))
 		Expect(miSelector.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
@@ -236,7 +236,7 @@ var _ = Describe("findAndAdoptInventory", func() {
 
 		Expect(r.Create(ctx, mInventory)).To(Succeed())
 
-		Expect(r.findAndAdoptInventory(ctx, miSelector)).To(Succeed())
+		Expect(r.findAndAdoptInventory(ctx, miSelector, &elementalv1.MachineInventory{})).To(Succeed())
 
 		Expect(miSelector.Status.Conditions).To(HaveLen(1))
 		Expect(miSelector.Status.Conditions[0].Type).To(Equal(elementalv1.ReadyCondition))
@@ -249,7 +249,7 @@ var _ = Describe("findAndAdoptInventory", func() {
 			Name: "test",
 		}
 
-		Expect(r.findAndAdoptInventory(ctx, miSelector)).To(Succeed())
+		Expect(r.findAndAdoptInventory(ctx, miSelector, &elementalv1.MachineInventory{})).To(Succeed())
 	})
 })
 
@@ -334,12 +334,12 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 	})
 
 	It("should do nothing if machine inventory ref is missing", func() {
-		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector)).To(Succeed())
+		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory)).To(Succeed())
 	})
 
 	It("should do nothing if bootstrap plan checksum is already set", func() {
 		miSelector.Status.BootstrapPlanChecksum = "test"
-		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector)).To(Succeed())
+		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory)).To(Succeed())
 	})
 
 	It("do nothing if machine inventory plan not ready yet", func() {
@@ -349,7 +349,7 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 			Name: mInventory.Name,
 		}
 
-		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector)).To(Succeed())
+		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory)).To(Succeed())
 	})
 
 	It("return error if failed to create new bootstrap plan", func() {
@@ -368,7 +368,7 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 			Name: mInventory.Name,
 		}
 
-		err := r.updatePlanSecretWithBootstrap(ctx, miSelector)
+		err := r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to get bootstrap plan"))
 	})
@@ -389,7 +389,7 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
 			Name: mInventory.Name,
 		}
-		err := r.updatePlanSecretWithBootstrap(ctx, miSelector)
+		err := r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to get plan secret"))
 	})
@@ -412,7 +412,7 @@ var _ = Describe("updatePlanSecretWithBootstrap", func() {
 		miSelector.Status.MachineInventoryRef = &corev1.LocalObjectReference{
 			Name: mInventory.Name,
 		}
-		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector)).To(Succeed())
+		Expect(r.updatePlanSecretWithBootstrap(ctx, miSelector, mInventory)).To(Succeed())
 
 		Expect(miSelector.Status.BootstrapPlanChecksum).ToNot(BeEmpty())
 		Expect(miSelector.Status.Conditions).To(HaveLen(1))
@@ -563,7 +563,7 @@ var _ = Describe("setInvetorySelectorAddresses", func() {
 	})
 
 	It("should return early if machine inventory reference is missing", func() {
-		Expect(r.setInvetorySelectorAddresses(ctx, miSelector)).To(Succeed())
+		Expect(r.setInvetorySelectorAddresses(ctx, miSelector, mInventory)).To(Succeed())
 	})
 
 	It("should return error if machine inventory is missing", func() {
@@ -571,7 +571,7 @@ var _ = Describe("setInvetorySelectorAddresses", func() {
 			Name: mInventory.Name,
 		}
 
-		err := r.setInvetorySelectorAddresses(ctx, miSelector)
+		err := r.setInvetorySelectorAddresses(ctx, miSelector, mInventory)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to get machine inventory"))
 	})
@@ -589,7 +589,7 @@ var _ = Describe("setInvetorySelectorAddresses", func() {
 		}
 		Expect(r.Create(ctx, mInventory)).To(Succeed())
 
-		err := r.setInvetorySelectorAddresses(ctx, miSelector)
+		err := r.setInvetorySelectorAddresses(ctx, miSelector, mInventory)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(miSelector.Status.Ready).To(BeTrue())


### PR DESCRIPTION
This PR adds a validation step in the process of adopting a MachineInventory by a MachineInventorySelector.

Machine inventory selectors are all competing to adopt a machine inventory resource. In order to avoid a machine inventory being adopted by more than one selector or vice versa this commit adds a validation process and tracks its status in a new adoption condition for the inventory resource.

The validation process is simple: on one side the machine inventory checks its owner includes the appropriate reference; on the other side the selector checks the reference in status points to a machine inventory owned by itself.

If an inconsistency is found during the validation the adoption process restarts. The bootstrap plan is not created until the adoption process is validated.

Related to #382