### PR TITLE
httpfy: support automated building

### DIFF
--- a/.obs/seedimage/Dockerfile
+++ b/.obs/seedimage/Dockerfile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# Define the names/tags of the container
+#!BuildTag: rancher/seedimage-builder/5.3:latest
+#!BuildTag: rancher/seedimage-builder/5.3:%OPERATOR_VERSION%
+#!BuildTag: rancher/seedimage-builder/5.3:%OPERATOR_VERSION%-%RELEASE%
+#
+
+FROM suse/sle15:15.4 as BASE
+
+RUN mkdir /installroot
+RUN  mkdir -p /installroot && \
+    zypper --gpg-auto-import-keys --installroot /installroot in -y --no-recommends elemental-httpfy xorriso curl coreutils ca-certificates ca-certificates-mozilla
+
+FROM scratch as SEEDIMAGE_BUILDER
+
+COPY --from=BASE /installroot /
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.rancher.elemental
+LABEL org.opencontainers.image.title="Rancher Elemental Seed Image Builder"
+LABEL org.opencontainers.image.description="Provides the tools needed to build Elemental Seed Images"
+LABEL org.opencontainers.image.version="%OPERATOR_VERSION%"
+LABEL org.opencontainers.image.url="https://github.com/rancher/elemental-operator"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="SUSE LLC"
+LABEL org.opensuse.reference="%%IMG_REPO%%/rancher/elemental-seedimage-builder-image/5.3"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL com.suse.supportlevel="techpreview"
+# endlabelprefix
+
+ENTRYPOINT ["elemental-httpfy"]

--- a/.obs/specfile/elemental-operator.spec
+++ b/.obs/specfile/elemental-operator.spec
@@ -56,6 +56,12 @@ Summary: Collect important logs for support
 This collects essential configuration files and logs to improve issue
 resolution.
 
+%package -n elemental-httpfy
+Summary: Simple http server
+
+%description -n elemental-httpfy
+httpfy starts a simple http server, serving files from the current dir.
+
 %prep
 %setup -q -n %{name}-%{version}
 cp %{S:1} .
@@ -79,6 +85,7 @@ export COMMITDATE=$(date -d @${MTIME} +%Y%m%d)
 CGO_ENABLED=0 make operator
 CGO_ENABLED=1 make register
 make support
+make httpfy
 
 %install
 %goinstall
@@ -91,6 +98,7 @@ make support
 %{__install} -m 755 build/elemental-operator %{buildroot}%{_sbindir}
 %{__install} -m 755 build/elemental-register %{buildroot}%{_sbindir}
 %{__install} -m 755 build/elemental-support %{buildroot}%{_sbindir}
+%{__install} -m 755 build/elemental-httpfy %{buildroot}%{_sbindir}
 
 %files
 %defattr(-,root,root,-)
@@ -107,5 +115,10 @@ make support
 %license LICENSE
 %{_sbindir}/elemental-support
 
+
+%files -n elemental-httpfy
+%defattr(-,root,root,-)
+%license LICENSE
+%{_sbindir}/elemental-httpfy
 
 %changelog

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ register:
 support:
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o $(BUILD_DIR)/elemental-support $(ROOT_DIR)/cmd/support
 
+.PHONY: httpfy
+httpfy:
+	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o $(BUILD_DIR)/elemental-httpfy $(ROOT_DIR)/utils/httpfy
+
 .PHONY: build-docker-operator
 build-docker-operator:
 	DOCKER_BUILDKIT=1 docker build \


### PR DESCRIPTION
This allows to build in OBS the httpfy package as part of the elemental-operator builds.
It also adds the Dockefile to be used in OBS to build the seed-image-builder container image.

Related to #401 .