### PR TITLE
Seedimage: add automatic cleanup of built images

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -158,4 +158,6 @@ const (
 	SeedImageExposeFailureReason = "SeedImageExposeFailure"
 	// SeedImageBuildSuccessReason documents seed image build job success.
 	SeedImageBuildSuccessReason = "SeedImageBuildSuccess"
+	// SeedImageBuildDeadline documents seed image build deadline has elapsed.
+	SeedImageBuildDeadline = "SeedImageBuildDeadline"
 )

--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -160,4 +160,6 @@ const (
 	SeedImageBuildSuccessReason = "SeedImageBuildSuccess"
 	// SeedImageBuildDeadline documents seed image build deadline has elapsed.
 	SeedImageBuildDeadline = "SeedImageBuildDeadline"
+	// SeedImageBuildUnknown documents seed image build job in unknown status.
+	SeedImageBuildUnknown = "SeedImageBuildUnknown"
 )

--- a/api/v1beta1/seedimage_type.go
+++ b/api/v1beta1/seedimage_type.go
@@ -28,6 +28,16 @@ type SeedImageSpec struct {
 	BaseImage string `json:"baseImage"`
 	// MachineRegistrationRef a reference to the related MachineRegistration.
 	MachineRegistrationRef *corev1.ObjectReference `json:"registrationRef"`
+	// LifetimeMinutes the time at which the built seed image will be cleaned up.
+	// If when the lifetime elapses the built image is being downloaded, the active
+	// download will be completed before removing the built image.
+	// Default is 60 minutes, set to 0 to disable.
+	// +kubebuilder:default:=60
+	// +optional
+	LifetimeMinutes int32 `json:"cleanupAfterMinutes"`
+	// RetriggerBuild triggers to build again a cleaned up seed image.
+	// +optional
+	RetriggerBuild bool `json:"retriggerBuild"`
 	// CloudConfig contains cloud-config data to be put in the generated iso.
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields

--- a/chart/templates/crds.yaml
+++ b/chart/templates/crds.yaml
@@ -2520,6 +2520,14 @@ spec:
                 description: BaseImg the base elemental image used to build the seed
                   image.
                 type: string
+              cleanupAfterMinutes:
+                default: 60
+                description: LifetimeMinutes the time at which the built seed image
+                  will be cleaned up. If when the lifetime elapses the built image
+                  is being downloaded, the active download will be completed before
+                  removing the built image. Default is 60 minutes, set to 0 to disable.
+                format: int32
+                type: integer
               cloud-config:
                 description: CloudConfig contains cloud-config data to be put in the
                   generated iso.
@@ -2561,6 +2569,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              retriggerBuild:
+                description: RetriggerBuild triggers to build again a cleaned up seed
+                  image.
+                type: boolean
             required:
             - registrationRef
             type: object

--- a/config/crd/bases/elemental.cattle.io_seedimages.yaml
+++ b/config/crd/bases/elemental.cattle.io_seedimages.yaml
@@ -37,6 +37,14 @@ spec:
                 description: BaseImg the base elemental image used to build the seed
                   image.
                 type: string
+              cleanupAfterMinutes:
+                default: 60
+                description: LifetimeMinutes the time at which the built seed image
+                  will be cleaned up. If when the lifetime elapses the built image
+                  is being downloaded, the active download will be completed before
+                  removing the built image. Default is 60 minutes, set to 0 to disable.
+                format: int32
+                type: integer
               cloud-config:
                 description: CloudConfig contains cloud-config data to be put in the
                   generated iso.
@@ -78,6 +86,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              retriggerBuild:
+                description: RetriggerBuild triggers to build again a cleaned up seed
+                  image.
+                type: boolean
             required:
             - registrationRef
             type: object

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -422,6 +422,7 @@ func (r *SeedImageReconciler) updateStatusFromPod(ctx context.Context, seedImg *
 		meta.SetStatusCondition(&seedImg.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.SeedImageConditionReady,
 			Status:  metav1.ConditionUnknown,
+			Reason:  elementalv1.SeedImageBuildUnknown,
 			Message: fmt.Sprintf("pod phase %s", foundPod.Status.Phase),
 		})
 		return nil

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -234,14 +234,7 @@ func (r *SeedImageReconciler) reconcileBuildImagePod(ctx context.Context, seedIm
 		logger.V(5).Info("Pod already there")
 
 		// ensure the pod was created by us
-		podIsOwned := false
-		for _, owner := range foundPod.GetOwnerReferences() {
-			if owner.UID == seedImg.UID {
-				podIsOwned = true
-				break
-			}
-		}
-		if !podIsOwned {
+		if !util.IsPodOwned(foundPod, seedImg.UID) {
 			return fmt.Errorf("pod already exists and was not created by this controller")
 		}
 

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -234,7 +234,7 @@ func (r *SeedImageReconciler) reconcileBuildImagePod(ctx context.Context, seedIm
 		logger.V(5).Info("Pod already there")
 
 		// ensure the pod was created by us
-		if !util.IsPodOwned(foundPod, seedImg.UID) {
+		if !util.IsObjectOwned(&foundPod.ObjectMeta, seedImg.UID) {
 			return fmt.Errorf("pod already exists and was not created by this controller")
 		}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,7 +23,6 @@ import (
 
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"gopkg.in/yaml.v3"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -102,8 +101,8 @@ func GetRancherCACert(ctx context.Context, cli client.Client) string {
 	return cacert
 }
 
-func IsPodOwned(pod *corev1.Pod, uid types.UID) bool {
-	for _, owner := range pod.GetOwnerReferences() {
+func IsObjectOwned(obj *metav1.ObjectMeta, uid types.UID) bool {
+	for _, owner := range obj.GetOwnerReferences() {
 		if owner.UID == uid {
 			return true
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,6 +23,7 @@ import (
 
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -99,4 +100,13 @@ func GetRancherCACert(ctx context.Context, cli client.Client) string {
 		}
 	}
 	return cacert
+}
+
+func IsPodOwned(pod *corev1.Pod, uid types.UID) bool {
+	for _, owner := range pod.GetOwnerReferences() {
+		if owner.UID == uid {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -97,3 +97,27 @@ func (w WriteFiles) DeepCopyObject() runtime.Object {
 }
 
 var _ runtime.Object = WriteFiles{}
+
+var _ = Describe("IsObjectOwned", func() {
+	obj := metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Name: "owner1",
+				UID:  "owner1UID",
+			},
+			{
+				Name: "owner2",
+				UID:  "owner2UID",
+			},
+		},
+	}
+
+	It("should return true when the passed owner UID is found", func() {
+		Expect(IsObjectOwned(&obj, "owner1UID")).To(BeTrue())
+		Expect(IsObjectOwned(&obj, "owner2UID")).To(BeTrue())
+	})
+	It("should return false when the passed owner UID is not found", func() {
+		Expect(IsObjectOwned(&obj, "owner3UID")).To(BeFalse())
+		Expect(IsObjectOwned(&metav1.ObjectMeta{}, "owner1UID")).To(BeFalse())
+	})
+})


### PR DESCRIPTION
This PR adds two new fields to the SeedImage resource, _TimeoutMinutes_ and _RetriggerBuild_.
 `TimeoutMinutes`  - it is the deadline (in minutes) after which the Pod containing the built seed image will be deleted once ready. Default is 60 minutes, set to 0 to disable.
 `RetriggerBuild` - needed to restart the build process of the seed image (useful if the Pod has been deleted due to an elapsed deadline).

Fixes #397 