### PR TITLE
unit tests: add MAC and Used Memory coverage

### DIFF
--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -104,71 +103,6 @@ func TestUnauthenticatedResponse(t *testing.T) {
 		assert.Equal(t, confReg.EmulateTPM, testReg.EmulateTPM)
 		assert.Equal(t, confReg.EmulatedTPMSeed, testReg.EmulatedTPMSeed)
 		assert.Equal(t, confReg.NoSMBIOS, testReg.NoSMBIOS)
-	}
-}
-
-func TestInitNewInventory(t *testing.T) {
-	const alphanum = "[0-9a-fA-F]"
-	// m  '-'  8 alphanum chars  '-'  3 blocks of 4 alphanum chars  '-'  12 alphanum chars
-	mUUID := regexp.MustCompile("^m-" + alphanum + "{8}-(" + alphanum + "{4}-){3}" + alphanum + "{12}")
-	// e.g., m-66588488-3eb6-4a6d-b642-c994f128c6f1
-
-	testCase := []struct {
-		config       *elementalv1.Config
-		initName     string
-		expectedName string
-	}{
-		{
-			config: &elementalv1.Config{
-				Elemental: elementalv1.Elemental{
-					Registration: elementalv1.Registration{
-						NoSMBIOS: false,
-					},
-				},
-			},
-			initName:     "custom-name",
-			expectedName: "custom-name",
-		},
-
-		{
-			config: &elementalv1.Config{
-				Elemental: elementalv1.Elemental{
-					Registration: elementalv1.Registration{
-						NoSMBIOS: false,
-					},
-				},
-			},
-		},
-		{
-			config: &elementalv1.Config{
-				Elemental: elementalv1.Elemental{
-					Registration: elementalv1.Registration{
-						NoSMBIOS: true,
-					},
-				},
-			},
-		},
-		{
-			config: nil,
-		},
-	}
-
-	for _, test := range testCase {
-		registration := &elementalv1.MachineRegistration{
-			Spec: elementalv1.MachineRegistrationSpec{
-				MachineName: test.initName,
-				Config:      test.config,
-			},
-		}
-
-		inventory := &elementalv1.MachineInventory{}
-		initInventory(inventory, registration)
-
-		if test.initName == "" {
-			assert.Check(t, mUUID.Match([]byte(inventory.Name)), inventory.Name+" is not UUID based")
-		} else {
-			assert.Equal(t, inventory.Name, test.expectedName)
-		}
 	}
 }
 

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -257,10 +257,12 @@ func TestUpdateInventoryFromSystemData(t *testing.T) {
 		Spec: elementalv1.MachineRegistrationSpec{
 			MachineInventoryLabels: map[string]string{
 				"elemental.cattle.io/TotalMemory":            "${System Data/Memory/Total Physical Bytes}",
+				"elemental.cattle.io/AvailableMemory":        "${System Data/Memory/Total Usable Bytes}",
 				"elemental.cattle.io/CpuTotalCores":          "${System Data/CPU/Total Cores}",
 				"elemental.cattle.io/CpuTotalThreads":        "${System Data/CPU/Total Threads}",
 				"elemental.cattle.io/NetIfacesNumber":        "${System Data/Network/Number Interfaces}",
 				"elemental.cattle.io/NetIface0-Name":         "${System Data/Network/myNic1/Name}",
+				"elemental.cattle.io/NetIface0-MAC":          "${System Data/Network/myNic1/MacAddress}",
 				"elemental.cattle.io/NetIface0-IsVirtual":    "${System Data/Network/myNic1/IsVirtual}",
 				"elemental.cattle.io/NetIface1-Name":         "${System Data/Network/myNic2/Name}",
 				"elemental.cattle.io/BlockDevicesNumber":     "${System Data/Block Devices/Number Devices}",
@@ -292,6 +294,7 @@ func TestUpdateInventoryFromSystemData(t *testing.T) {
 		Memory: &memory.Info{
 			Area: memory.Area{
 				TotalPhysicalBytes: 100,
+				TotalUsableBytes:   90,
 			},
 		},
 		CPU: &cpu.Info{
@@ -301,8 +304,9 @@ func TestUpdateInventoryFromSystemData(t *testing.T) {
 		Network: &net.Info{
 			NICs: []*net.NIC{
 				{
-					Name:      "myNic1",
-					IsVirtual: true,
+					Name:       "myNic1",
+					MacAddress: "02:00:00:00:00:01",
+					IsVirtual:  true,
 				},
 				{
 					Name: "myNic2",
@@ -316,10 +320,12 @@ func TestUpdateInventoryFromSystemData(t *testing.T) {
 	assert.NilError(t, err)
 	// Check that the labels we properly added to the inventory
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/TotalMemory"], "100")
+	assert.Equal(t, inventory.Labels["elemental.cattle.io/TotalMemory"], "100")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/CpuTotalCores"], "300")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/CpuTotalThreads"], "300")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/NetIfacesNumber"], "2")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/NetIface0-Name"], "myNic1")
+	assert.Equal(t, inventory.Labels["elemental.cattle.io/NetIface0-MAC"], "02-00-00-00-00-01")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/NetIface0-IsVirtual"], "true")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/NetIface1-Name"], "myNic2")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/BlockDevicesNumber"], "2")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"regexp"
+	"testing"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"gotest.tools/assert"
+)
+
+func TestInitNewInventory(t *testing.T) {
+	const alphanum = "[0-9a-fA-F]"
+	// m  '-'  8 alphanum chars  '-'  3 blocks of 4 alphanum chars  '-'  12 alphanum chars
+	mUUID := regexp.MustCompile("^m-" + alphanum + "{8}-(" + alphanum + "{4}-){3}" + alphanum + "{12}")
+	// e.g., m-66588488-3eb6-4a6d-b642-c994f128c6f1
+
+	testCase := []struct {
+		config       *elementalv1.Config
+		initName     string
+		expectedName string
+	}{
+		{
+			config: &elementalv1.Config{
+				Elemental: elementalv1.Elemental{
+					Registration: elementalv1.Registration{
+						NoSMBIOS: false,
+					},
+				},
+			},
+			initName:     "custom-name",
+			expectedName: "custom-name",
+		},
+
+		{
+			config: &elementalv1.Config{
+				Elemental: elementalv1.Elemental{
+					Registration: elementalv1.Registration{
+						NoSMBIOS: false,
+					},
+				},
+			},
+		},
+		{
+			config: &elementalv1.Config{
+				Elemental: elementalv1.Elemental{
+					Registration: elementalv1.Registration{
+						NoSMBIOS: true,
+					},
+				},
+			},
+		},
+		{
+			config: nil,
+		},
+	}
+
+	for _, test := range testCase {
+		registration := &elementalv1.MachineRegistration{
+			Spec: elementalv1.MachineRegistrationSpec{
+				MachineName: test.initName,
+				Config:      test.config,
+			},
+		}
+
+		inventory := &elementalv1.MachineInventory{}
+		initInventory(inventory, registration)
+
+		if test.initName == "" {
+			assert.Check(t, mUUID.Match([]byte(inventory.Name)), inventory.Name+" is not UUID based")
+		} else {
+			assert.Equal(t, inventory.Name, test.expectedName)
+		}
+	}
+}


### PR DESCRIPTION
Moreover, move functions from server.go to the newer server_test.go.
