### PR TITLE
Use config map in seedimage pod

### DIFF
--- a/api/v1beta1/machineregistration_types.go
+++ b/api/v1beta1/machineregistration_types.go
@@ -74,6 +74,30 @@ type MachineRegistrationList struct {
 	Items           []MachineRegistration `json:"items"`
 }
 
+// GetClientRegistrationConfig returns the configuration required by the elemental-register
+// to register itself against this MachineRegistration instance.
+func (m MachineRegistration) GetClientRegistrationConfig(cacert string) *Config {
+	conf := m.Spec.Config
+
+	if conf == nil {
+		conf = &Config{}
+	}
+
+	mRegistration := conf.Elemental.Registration
+
+	return &Config{
+		Elemental: Elemental{
+			Registration: Registration{
+				URL:             m.Status.RegistrationURL,
+				CACert:          cacert,
+				EmulateTPM:      mRegistration.EmulateTPM,
+				EmulatedTPMSeed: mRegistration.EmulatedTPMSeed,
+				NoSMBIOS:        mRegistration.NoSMBIOS,
+			},
+		},
+	}
+}
+
 func init() {
 	SchemeBuilder.Register(&MachineRegistration{}, &MachineRegistrationList{})
 }

--- a/chart/templates/cluster_role.yaml
+++ b/chart/templates/cluster_role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/config/rbac/bases/role.yaml
+++ b/config/rbac/bases/role.yaml
@@ -8,6 +8,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -225,8 +225,7 @@ func (r *SeedImageReconciler) reconcileBuildImagePod(ctx context.Context, seedIm
 		}
 
 		// pod is already there and with the right configuration
-		if foundPod.Annotations["elemental.cattle.io/base-image"] == podBaseImg &&
-			foundPod.Annotations["elemental.cattle.io/configmap-uid"] == string(podConfigMap.ObjectMeta.UID) {
+		if foundPod.Annotations["elemental.cattle.io/base-image"] == podBaseImg {
 			return r.updateStatusFromPod(ctx, seedImg, foundPod)
 		}
 
@@ -419,8 +418,7 @@ func fillBuildImagePod(name, namespace, buildImg, baseImg string, pullPolicy cor
 			Namespace: namespace,
 			Labels:    map[string]string{"app.kubernetes.io/name": name},
 			Annotations: map[string]string{
-				"elemental.cattle.io/base-image":    baseImg,
-				"elemental.cattle.io/configmap-uid": string(configMap.ObjectMeta.UID),
+				"elemental.cattle.io/base-image": baseImg,
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/controllers/seedimage_controller_test.go
+++ b/controllers/seedimage_controller_test.go
@@ -252,7 +252,6 @@ var _ = Describe("reconcileBuildImagePod", func() {
 			Name:      seedImg.Name,
 			Namespace: seedImg.Namespace,
 		}, foundPod)).To(Succeed())
-		Expect(foundPod.Annotations["elemental.cattle.io/cloud-config-b64"]).To(Equal(""))
 
 		seedImg.Spec.CloudConfig = map[string]runtime.RawExtension{
 			"write_files": {},
@@ -264,6 +263,5 @@ var _ = Describe("reconcileBuildImagePod", func() {
 			Name:      seedImg.Name,
 			Namespace: seedImg.Namespace,
 		}, foundPod)).To(Succeed())
-		Expect(foundPod.Annotations["elemental.cattle.io/cloud-config-b64"]).To(Equal("I2Nsb3VkLWNvbmZpZwp3cml0ZV9maWxlczoKbnVsbAo="))
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.25.4
 	k8s.io/apiserver v0.24.0 // indirect
 	k8s.io/component-base v0.26.0 // indirect

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -123,23 +123,8 @@ func (i *InventoryServer) apiRegistration(resp http.ResponseWriter, req *http.Re
 }
 
 func (i *InventoryServer) unauthenticatedResponse(registration *elementalv1.MachineRegistration, writer io.Writer) error {
-	if registration.Spec.Config == nil {
-		registration.Spec.Config = &elementalv1.Config{}
-	}
-
-	mRegistration := registration.Spec.Config.Elemental.Registration
-
-	return yaml.NewEncoder(writer).Encode(elementalv1.Config{
-		Elemental: elementalv1.Elemental{
-			Registration: elementalv1.Registration{
-				URL:             registration.Status.RegistrationURL,
-				CACert:          i.getRancherCACert(),
-				EmulateTPM:      mRegistration.EmulateTPM,
-				EmulatedTPMSeed: mRegistration.EmulatedTPMSeed,
-				NoSMBIOS:        mRegistration.NoSMBIOS,
-			},
-		},
-	})
+	return yaml.NewEncoder(writer).
+		Encode(registration.GetClientRegistrationConfig(i.getRancherCACert()))
 }
 
 func (i *InventoryServer) writeMachineInventoryCloudConfig(conn *websocket.Conn, protoVersion register.MessageType, inventory *elementalv1.MachineInventory, registration *elementalv1.MachineRegistration) error {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
This PR uses a config map to inject the configuration files into the seedimage-builder container. Basically it allows to simplify the command executed by the pod and it prevents having to download any information that is already managed by the operator such as the registration config yaml.