### PR TITLE
Pull iso as a container

### DIFF
--- a/pkg/util/suite_test.go
+++ b/pkg/util/suite_test.go
@@ -17,13 +17,58 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rancher/elemental-operator/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Util Suite")
 }
+
+var (
+	testEnv *envtest.Environment
+	cfg     *rest.Config
+	cl      client.Client
+	ctx     = context.Background()
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	var err error
+	testEnv = &envtest.Environment{}
+	cfg, cl, err = test.StartEnvTest(testEnv)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+	Expect(cl).NotTo(BeNil())
+
+	Expect(cl.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "custom",
+		},
+	})).To(Succeed())
+
+	Expect(cl.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fleet-local",
+		},
+	})).To(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	Expect(test.StopEnvTest(testEnv)).To(Succeed())
+})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 
 	managementv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"gopkg.in/yaml.v3"
@@ -108,4 +110,13 @@ func IsObjectOwned(obj *metav1.ObjectMeta, uid types.UID) bool {
 		}
 	}
 	return false
+}
+
+func IsHTTP(uri string) bool {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return false
+	}
+
+	return strings.HasPrefix(parsed.Scheme, "http")
 }


### PR DESCRIPTION
This PR allows to pull the base ISO as a container or from an HTTP URL. The logic to use one or the other is based done by parsing the URL, any HTTP URL will use curl to download the ISO and anything else will attempted to be used as a container reference.

Fixes #396