### PR TITLE
Merge default command and image in containersSpec

### DIFF
--- a/controllers/managedosimage_controller.go
+++ b/controllers/managedosimage_controller.go
@@ -208,12 +208,15 @@ func (r *ManagedOSImageReconciler) newFleetBundleResources(ctx context.Context, 
 	}
 
 	if upgradeContainerSpec == nil {
-		upgradeContainerSpec = &upgradev1.ContainerSpec{
-			Image: prefixPrivateRegistry(image[0], r.DefaultRegistry),
-			Command: []string{
-				"/usr/sbin/suc-upgrade",
-			},
-		}
+		upgradeContainerSpec = &upgradev1.ContainerSpec{}
+	}
+
+	if upgradeContainerSpec.Image == "" {
+		upgradeContainerSpec.Image = prefixPrivateRegistry(image[0], r.DefaultRegistry)
+	}
+
+	if len(upgradeContainerSpec.Command) == 0 {
+		upgradeContainerSpec.Command = []string{"/usr/sbin/suc-upgrade"}
 	}
 
 	// Encode metadata from the spec as environment in the upgrade spec pod


### PR DESCRIPTION
This commit makes use of the default and command and image values for ManagedOSImage updateContianerSpec if they are not defined despite having other updateContainerSpec values defined.