### PR TITLE
Add channel hook-failed delete policy 

### DIFF
--- a/chart/templates/channel-hook.yaml
+++ b/chart/templates/channel-hook.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: fleet-default
   annotations:
     "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-failed
 spec:
   options:
     image: {{ .Values.channel.repository }}:{{ .Values.channel.tag }}


### PR DESCRIPTION
This commits prevent running a delete before launching the hook.
This prevents a race condition in case the new CRD was not yet cached on the client running the deletion.

Fixes #438