### PR TITLE
GoReleaser: fix releases CI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -83,6 +83,8 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 sboms:
   - artifacts: binary
+    documents:
+      - "${artifact}.sbom"
 signs:
   - cmd: cosign
     signature: "${artifact}.sig"


### PR DESCRIPTION
the SBOM files produced by goreleaser have the following default name for binaries artifacts:
["{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"]

Just name the SBOM with the artifact name.

Fixes #443 