### PR TITLE
Fix OBS PR workflow

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -65,6 +65,12 @@ pr_workflow:
         source_project: isv:Rancher:Elemental:Dev:Teal53
         source_package: seedimage-builder
         target_project: isv:Rancher:Elemental:PR:Teal53
+    - set_flags:
+        flags:
+          - type: build
+            repository: images
+            status: disable
+            project: isv:Rancher:Elemental:PR
   filters:
     event: pull_request
     branches:


### PR DESCRIPTION
By default we have the image repo enabled in the branched project from the OBS PR workflow: disable it as we don't want to build the ISO there.

Fixes #445 