### PR TITLE
OBS PR workflow: set the right project to disable images repo

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -70,7 +70,7 @@ pr_workflow:
           - type: build
             repository: images
             status: disable
-            project: isv:Rancher:Elemental:PR
+            project: isv:Rancher:Elemental:PR:Teal53
   filters:
     event: pull_request
     branches:


### PR DESCRIPTION
This corrects the project link in #446 🤦🏼 

Should fix #445