### PR TITLE
Charts: add template checking CRDs installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,13 @@ chart:
 	helm package --version ${CHART_VERSION} --app-version ${GIT_TAG} -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/operator
 	rm -Rf $(ROOT_DIR)/build/operator
 
+.PHONY: migration-chart
+migration-chart:
+	mkdir -p  $(ROOT_DIR)/build
+	cp -rf $(ROOT_DIR)/charts/crds-migration $(ROOT_DIR)/build/crds-migration
+	helm package -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/crds-migration
+	rm -Rf $(ROOT_DIR)/build/crds-migration
+
 validate:
 	scripts/validate
 

--- a/charts/crds-migration/Chart.yaml
+++ b/charts/crds-migration/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: elemental-operator-crds-migration
+decription: A Helm chart for enabling the upgrade from Elemental Operator releases < 1.2.4
+version: 0.0.1

--- a/charts/crds-migration/templates/pre-install-hook.yaml
+++ b/charts/crds-migration/templates/pre-install-hook.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-helm-hook
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -13,7 +13,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}-helm-hook
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -31,7 +31,7 @@ metadata:
   name: {{ .Release.Name }}-helm-hook
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -47,8 +47,7 @@ spec:
           - "kubectl"
           - "annotate"
           - "crds"
-          - "--selector=release-name={{ .Release.Name }}"
-          - "--namespace={{ .Release.Namespace }}"
+          - "--selector=release-name={{ .Values.legacyReleaseName }}"
           - "helm.sh/resource-policy=keep"
           - "--overwrite=true"
       - name: crd-release-name
@@ -57,9 +56,8 @@ spec:
           - "kubectl"
           - "annotate"
           - "crds"
-          - "--selector=release-name={{ .Release.Name }}"
-          - "--namespace={{ .Release.Namespace }}"
-          - "meta.helm.sh/release-name={{ .Release.Name }}-crds"
+          - "--selector=release-name={{ .Values.legacyReleaseName }}"
+          - "meta.helm.sh/release-name={{ .Values.newCRDsReleaseName }}"
           - "--overwrite=true"
       restartPolicy: Never
   backoffLimit: 2

--- a/charts/crds-migration/values.yaml
+++ b/charts/crds-migration/values.yaml
@@ -1,0 +1,2 @@
+legacyReleaseName: "elemental-operator"
+newCRDsReleaseName: "elemental-operator-crds"

--- a/charts/operator/templates/validate-install-crd.yaml
+++ b/charts/operator/templates/validate-install-crd.yaml
@@ -1,0 +1,25 @@
+{{ if gt (len (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "")) 0 }}
+  {{ $apis := dict
+    "elemental.cattle.io/v1beta1/MachineInventory" "machineinventories"
+    "elemental.cattle.io/v1beta1/MachineInventorySelector" "machineinventoryselectors"
+    "elemental.cattle.io/v1beta1/MachineInventorySelectorTemplate" "machineinventoryselectortemplates"
+    "elemental.cattle.io/v1beta1/MachineRegistration" "machineregistrations"
+    "elemental.cattle.io/v1beta1/ManagedOSImage" "managedosimages"
+    "elemental.cattle.io/v1beta1/ManagedOSVersionChannel" "managedosversionchannels"
+    "elemental.cattle.io/v1beta1/ManagedOSVersion" "managedosversions"
+    "elemental.cattle.io/v1beta1/SeedImage" "seedimages"
+  }}
+  {{- range $api, $crd := $apis -}}
+    {{- if not ($.Capabilities.APIVersions.Has $api) -}}
+      {{- required "Required CRDs are missing. Please install the corresponding CRD chart before installing this chart." "" -}}
+    {{- end -}}
+    {{- $crdobj := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" (print $crd ".elemental.cattle.io") -}}
+    {{- if not $crdobj -}}
+      {{- print "Cannot lookup " $crd ".elemental.cattle.io crd object" | fail -}}
+    {{- end -}}
+    {{- $crdrelease := index $crdobj.metadata.annotations "meta.helm.sh/release-name" -}}
+    {{- if eq $crdrelease $.Release.Name -}}
+      {{- required "Elemental CRDs should be moved to the new elemental-operator-crds chart before upgrading this operator." "" -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
This PR adds a template to the elemental-operator chart to check: 
1. if the elemental crds are installed
2. if the elemental crds are installed with a release name different than the current one

If one of the above checks fails, the installation/upgrade fails with an error message.
The pre-hook for changing the CRDs annotations is no more of use inside the elemental-operator chart and so has been moved to a separate new chart: elemental-operator-crds-migration.
No plan to keep building this new chart for releases, but could be handy to have it around for a while (we may want at some point to build it once).

Fixes #463
