### PR TITLE
Fix elemental managed label value to match backup operator expectations

### DIFF
--- a/api/v1beta1/common_consts.go
+++ b/api/v1beta1/common_consts.go
@@ -19,4 +19,7 @@ package v1beta1
 const (
 	// ElementalManagedLabel label used to put on resources managed by the elemental operator.
 	ElementalManagedLabel = "elemental.cattle.io/managed"
+
+	// SASecretSuffix is the suffix used to name registration service account's token secret
+	SASecretSuffix = "-token"
 )

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -174,7 +174,7 @@ func (r *MachineInventoryReconciler) createPlanSecret(ctx context.Context, mInve
 				},
 			},
 			Labels: map[string]string{
-				elementalv1.ElementalManagedLabel: "",
+				elementalv1.ElementalManagedLabel: "true",
 			},
 		},
 		Type:       elementalv1.PlanSecretType,

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -240,11 +240,6 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 				elementalv1.ElementalManagedLabel: "true",
 			},
 		},
-		Secrets: []corev1.ObjectReference{
-			{
-				Name: mRegistration.Name + "-token",
-			},
-		},
 	}); err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create service account: %w", err)
 	}
@@ -252,7 +247,7 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 	logger.Info("Creating token secret for the service account")
 	if err := r.Create(ctx, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            mRegistration.Name + "-token",
+			Name:            mRegistration.Name + elementalv1.SASecretSuffix,
 			Namespace:       mRegistration.Namespace,
 			OwnerReferences: ownerReferences,
 			Annotations: map[string]string{

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -213,7 +213,7 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 			Namespace:       mRegistration.Namespace,
 			OwnerReferences: ownerReferences,
 			Labels: map[string]string{
-				elementalv1.ElementalManagedLabel: "",
+				elementalv1.ElementalManagedLabel: "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{{
@@ -237,7 +237,7 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 			Namespace:       mRegistration.Namespace,
 			OwnerReferences: ownerReferences,
 			Labels: map[string]string{
-				elementalv1.ElementalManagedLabel: "",
+				elementalv1.ElementalManagedLabel: "true",
 			},
 		},
 		Secrets: []corev1.ObjectReference{
@@ -259,7 +259,7 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 				"kubernetes.io/service-account.name": mRegistration.Name,
 			},
 			Labels: map[string]string{
-				elementalv1.ElementalManagedLabel: "",
+				elementalv1.ElementalManagedLabel: "true",
 			},
 		},
 		Type: corev1.SecretTypeServiceAccountToken,
@@ -274,7 +274,7 @@ func (r *MachineRegistrationReconciler) createRBACObjects(ctx context.Context, m
 			Name:            mRegistration.Name,
 			OwnerReferences: ownerReferences,
 			Labels: map[string]string{
-				elementalv1.ElementalManagedLabel: "",
+				elementalv1.ElementalManagedLabel: "true",
 			},
 		},
 		Subjects: []rbacv1.Subject{{

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -137,13 +137,9 @@ func (i *InventoryServer) writeMachineInventoryCloudConfig(conn *websocket.Conn,
 		return fmt.Errorf("failed to get service account: %w", err)
 	}
 
-	if len(sa.Secrets) == 0 {
-		return fmt.Errorf("no secrets associated to the %s/%s service account", sa.Namespace, sa.Name)
-	}
-
 	secret := &corev1.Secret{}
 	err := i.Get(i, types.NamespacedName{
-		Name:      sa.Secrets[0].Name,
+		Name:      sa.Name + elementalv1.SASecretSuffix,
 		Namespace: sa.Namespace,
 	}, secret)
 

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -787,7 +787,7 @@ func createDefaultResources(t *testing.T, server *InventoryServer) {
 	t.Helper()
 	server.Client.Create(context.Background(), &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-secret",
+			Name: "test-account-token",
 		},
 
 		Type: v1.SecretTypeServiceAccountToken,
@@ -796,12 +796,6 @@ func createDefaultResources(t *testing.T, server *InventoryServer) {
 	server.Client.Create(context.Background(), &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-account",
-		},
-
-		Secrets: []v1.ObjectReference{
-			{
-				Name: "test-secret",
-			},
 		},
 	})
 


### PR DESCRIPTION
This PR ensures the token secret is kept in the backup tarball. Label `elemental.cattle.io/managed` needs to be set to `true` to actually be included within the backup according to https://github.com/rancher/backup-restore-operator/commit/52640728ca972d03e3b9861bcf28d40cc6819ada

Fixes https://github.com/rancher/elemental/issues/776

**Note**: this PR does not fix any pre-existing resource, so upgrading operator and backing up is not enough to backup pre-existing resources. More specific,  `MachineInventories` and `MachineRegistrations` secrets created by Elemental should switch the label `elemental.cattle.io/managed` value from an empty string to `true`. The same applies for `Roles`, `Rolebindings` and `ServiceAccounts` owned by `MachineRegistrations`. Any MachineRegistration and MachineInventory resource created with an operator including this patch is already prepared to be properly restored from a backup.