### PR TITLE
Recreate service account token secret if missing

### DIFF
--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -74,7 +74,8 @@ func (r *MachineInventoryReconciler) Reconcile(ctx context.Context, req reconcil
 		return reconcile.Result{}, fmt.Errorf("failed to get machine inventory object: %w", err)
 	}
 
-	patchBase := client.MergeFrom(mInventory.DeepCopy())
+	// Ensure we patch the latest version otherwise we could erratically overlap with other controllers (e.g. backup and restore)
+	patchBase := client.MergeFromWithOptions(mInventory.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	// We have to sanitize the conditions because old API definitions didn't have proper validation.
 	mInventory.Status.Conditions = util.RemoveInvalidConditions(mInventory.Status.Conditions)
@@ -90,7 +91,7 @@ func (r *MachineInventoryReconciler) Reconcile(ctx context.Context, req reconcil
 	machineInventoryStatusCopy := mInventory.Status.DeepCopy() // Patch call will erase the status
 
 	if err := r.Patch(ctx, mInventory, patchBase); err != nil {
-		errs = append(errs, fmt.Errorf("failed to patch status for machine inventory object: %w", err))
+		errs = append(errs, fmt.Errorf("failed to patch machine inventory object: %w", err))
 	}
 
 	mInventory.Status = *machineInventoryStatusCopy

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -106,7 +106,7 @@ func (r *MachineInventorySelectorReconciler) Reconcile(ctx context.Context, req 
 	machineInventorySelectorStatusCopy := machineInventorySelector.Status.DeepCopy() // Patch call will erase the status
 
 	if err := r.Patch(ctx, machineInventorySelector, patchBase); err != nil {
-		errs = append(errs, fmt.Errorf("failed to patch status for machine inventory selector object: %w", err))
+		errs = append(errs, fmt.Errorf("failed to patch machine inventory selector object: %w", err))
 	}
 
 	machineInventorySelector.Status = *machineInventorySelectorStatusCopy

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -200,7 +200,6 @@ var _ = Describe("reconcile managed os version channel", func() {
 	It("should reconcile and sync managed os version channel object with default sync time", func() {
 		managedOSVersion := &elementalv1.ManagedOSVersion{}
 		managedOSVersionChannel.Spec.Type = "custom"
-
 		name := types.NamespacedName{
 			Namespace: managedOSVersionChannel.Namespace,
 			Name:      managedOSVersionChannel.Name,
@@ -209,6 +208,10 @@ var _ = Describe("reconcile managed os version channel", func() {
 
 		// No error and status updated (triggers requeue)
 		res1, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
+		Expect(err).To(HaveOccurred()) // Can't update status if spec changed
+		Expect(res1.Requeue).To(BeTrue())
+
+		res1, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: name})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(res1.RequeueAfter).To(Equal(0 * time.Second))
 

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -95,7 +95,7 @@ func (r *SeedImageReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	seedImgStatusCopy := seedImg.Status.DeepCopy() // Patch call will erase the status
 
 	if err := r.Patch(ctx, seedImg, patchBase); err != nil && !apierrors.IsNotFound(err) {
-		errs = append(errs, fmt.Errorf("failed to patch status for seedimage object: %w", err))
+		errs = append(errs, fmt.Errorf("failed to patch seedimage object: %w", err))
 	}
 
 	seedImg.Status = *seedImgStatusCopy


### PR DESCRIPTION
This commit checks on each reconcile loop if the service account token secret is missing despite being on ready state.

In addition it also adds optimistic locking for patch calls. The motivations is to prevent concurrent controllers to modify outdated data.

Fixes rancher/elemental#776