### PR TITLE
Fixed a typo in the tag version string for elemental-teal-channel in helm

### DIFF
--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -11,7 +11,7 @@ seedImage:
 
 channel:
   repository: "%%IMG_REPO%%/rancher/elemental-teal-channel" 
-  tag: "%VESION%"
+  tag: "%VERSION%"
 
 # number of operator replicas to deploy
 replicas: 1


### PR DESCRIPTION
Fixes: #494 