### PR TITLE
Disable service triggers on staging

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -24,34 +24,19 @@ push_workflow:
 tag_workflow:
   steps:
     - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: elemental-operator
-    - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: elemental-operator
-    - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: elemental-operator-helm
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: elemental-operator-helm
     - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: elemental-operator-crds-helm
-    - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: elemental-operator-crds-helm
-    - trigger_services:
-        project: isv:Rancher:Elemental:Staging
-        package: operator-image
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
         package: operator-image
     - trigger_services:
         project: isv:Rancher:Elemental:Dev
-        package: seedimage-builder
-    - trigger_services:
-        project: isv:Rancher:Elemental:Staging
         package: seedimage-builder
   filters:
     event: tag_push


### PR DESCRIPTION
Since all services are set to `manual` or `buildtime` in staging, triggering services has no effect. Staging has to be updated manually.

Related to rancher/elemental#971 and rancher/elemental-toolkit#1817