### PR TITLE
Add CAPI cluster role to helm chart

### DIFF
--- a/charts/operator/templates/capi_rbac.yaml
+++ b/charts/operator/templates/capi_rbac.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elemental-capi-role
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+rules:
+  - apiGroups: ["elemental.cattle.io"]
+    resources: ["*"]
+    verbs: ["*"]


### PR DESCRIPTION
CAPI controller was moved into a separate pod, previously it was embedded into Rancher. CAPI controller interacts with elemental resources and this migration requires a separate set of RBAC rules for the new CAPI pod, current permissions are limited to the upstream resources and rancher specific objects, elemental CRs are not included. This PR adds a cluster role with required permissions, it will be merged later as an [aggregated role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles) with the CAPI controller one. 