### PR TITLE
Charts: always use camelCase for values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ chart:
 	yq -i '.seedImage.repository = "${REPO_SEEDIMAGE}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.channel.tag = "${TAG_CHANNEL}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.channel.repository = "${REPO_CHANNEL}"' $(ROOT_DIR)/build/operator/values.yaml
-	yq -i '.registry_url = "${REGISTRY_URL}"' $(ROOT_DIR)/build/operator/values.yaml
+	yq -i '.registryUrl = "${REGISTRY_URL}"' $(ROOT_DIR)/build/operator/values.yaml
 	helm package --version ${CHART_VERSION} --app-version ${CHART_VERSION} -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/operator
 	rm -Rf $(ROOT_DIR)/build/operator
 

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -9,8 +9,8 @@
 {{- define "registry_url" -}}
 {{- if .Values.global.cattle.systemDefaultRegistry -}}
 {{ include "system_default_registry" . }}
-{{- else if .Values.registry_url -}}
-{{- printf "%s/" .Values.registry_url -}}
+{{- else if .Values.registryUrl -}}
+{{- printf "%s/" .Values.registryUrl -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -27,7 +27,7 @@ global:
     systemDefaultRegistry: ""
 
 # used only if systemDefaultRegistry is empty
-registry_url: ""
+registryUrl: ""
 
 # enable debug output for operator
 debug: false


### PR DESCRIPTION
`registry_url` slipped in while we wanted there `registryUrl`

Fixes commit #742b414ba326ae78a30dea4849aa71c478a70d4c