### PR TITLE
register: add no-toolkit CLI option for pre-installed hosts

### DIFF
--- a/api/v1beta1/machineinventory_types.go
+++ b/api/v1beta1/machineinventory_types.go
@@ -22,13 +22,14 @@ import (
 )
 
 var (
-	MachineInventoryFinalizer                              = "machineinventory.elemental.cattle.io"
-	PlanSecretType                       corev1.SecretType = "elemental.cattle.io/plan"
-	PlanTypeAnnotation                                     = "elemental.cattle.io/plan.type"
-	PlanTypeEmpty                                          = "empty"
-	PlanTypeBootstrap                                      = "bootstrap"
-	PlanTypeReset                                          = "reset"
-	MachineInventoryResettableAnnotation                   = "elemental.cattle.io/resettable"
+	MachineInventoryFinalizer                               = "machineinventory.elemental.cattle.io"
+	PlanSecretType                        corev1.SecretType = "elemental.cattle.io/plan"
+	PlanTypeAnnotation                                      = "elemental.cattle.io/plan.type"
+	PlanTypeEmpty                                           = "empty"
+	PlanTypeBootstrap                                       = "bootstrap"
+	PlanTypeReset                                           = "reset"
+	MachineInventoryResettableAnnotation                    = "elemental.cattle.io/resettable"
+	MachineInventoryOSUnmanagedAnnotation                   = "elemental.cattle.io/os.unmanaged"
 )
 
 type MachineInventorySpec struct {

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -85,6 +85,8 @@ type Registration struct {
 	// +optional
 	// +kubebuilder:default:=tpm
 	Auth string `json:"auth,omitempty" yaml:"auth,omitempty" mapstructure:"auth"`
+	// +optional
+	NoToolkit bool `json:"no-toolkit,omitempty" yaml:"no-toolkit,omitempty" mapstructure:"no-toolkit"`
 }
 
 type SystemAgent struct {

--- a/charts/crds/templates/crds.yaml
+++ b/charts/crds/templates/crds.yaml
@@ -702,6 +702,8 @@ spec:
                             type: integer
                           no-smbios:
                             type: boolean
+                          no-toolkit:
+                            type: boolean
                           url:
                             type: string
                         type: object

--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -47,7 +47,6 @@ var (
 	debug        bool
 	reset        bool
 	installation bool
-	noToolkit    bool
 	configPath   string
 	statePath    string
 )
@@ -120,7 +119,7 @@ func newCommand(fs vfs.FS, client register.Client, stateHandler register.StateHa
 			// Install
 			if installation {
 				// Optionally install agent config to local filesystem (no install)
-				if noToolkit {
+				if cfg.Elemental.Registration.NoToolkit {
 					log.Info("Installing local agent config")
 					if err := installer.WriteLocalSystemAgentConfig(cfg.Elemental); err != nil {
 						return fmt.Errorf("Installing local agent config")
@@ -135,7 +134,7 @@ func newCommand(fs vfs.FS, client register.Client, stateHandler register.StateHa
 			}
 			// Reset
 			if reset {
-				if noToolkit {
+				if cfg.Elemental.Registration.NoToolkit {
 					log.Warning("Reset not supported for no-toolkit hosts")
 				} else {
 					log.Info("Resetting Elemental")
@@ -169,7 +168,7 @@ func newCommand(fs vfs.FS, client register.Client, stateHandler register.StateHa
 	_ = viper.BindPFlag("version", cmd.PersistentFlags().Lookup("version"))
 	cmd.Flags().BoolVar(&reset, "reset", false, "Reset the machine to its original post-installation state")
 	cmd.Flags().BoolVar(&installation, "install", false, "Install a new machine")
-	cmd.Flags().BoolVar(&noToolkit, "no-toolkit", false, "No OS management via elemental-toolkit, only Install agent config files to local filesystem (for pre-installed hosts)")
+	cmd.Flags().BoolVar(&cfg.Elemental.Registration.NoToolkit, "no-toolkit", false, "No OS management via elemental-toolkit, only Install agent config files to local filesystem (for pre-installed hosts)")
 	return cmd
 }
 

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -86,6 +86,8 @@ spec:
                             type: integer
                           no-smbios:
                             type: boolean
+                          no-toolkit:
+                            type: boolean
                           url:
                             type: string
                         type: object

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -186,8 +186,9 @@ func (r *MachineInventoryReconciler) reconcileResetPlanSecret(ctx context.Contex
 
 	logger.Info("Reconciling Reset plan")
 
-	resettable, found := mInventory.Annotations[elementalv1.MachineInventoryResettableAnnotation]
-	if !found || resettable != "true" {
+	resettable, resettableFound := mInventory.Annotations[elementalv1.MachineInventoryResettableAnnotation]
+	unmanaged, unmanagedFound := mInventory.Annotations[elementalv1.MachineInventoryOSUnmanagedAnnotation]
+	if (!resettableFound || resettable != "true") || (unmanagedFound && unmanaged == "true") {
 		logger.V(log.DebugDepth).Info("Machine Inventory does not need reset. Removing finalizer.")
 		controllerutil.RemoveFinalizer(mInventory, elementalv1.MachineInventoryFinalizer)
 		return nil

--- a/pkg/install/mocks/install.go
+++ b/pkg/install/mocks/install.go
@@ -80,3 +80,17 @@ func (mr *MockInstallerMockRecorder) ResetElemental(arg0, arg1 interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetElemental", reflect.TypeOf((*MockInstaller)(nil).ResetElemental), arg0, arg1)
 }
+
+// WriteLocalSystemAgentConfig mocks base method.
+func (m *MockInstaller) WriteLocalSystemAgentConfig(arg0 v1beta1.Elemental) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteLocalSystemAgentConfig", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WriteLocalSystemAgentConfig indicates an expected call of WriteLocalSystemAgentConfig.
+func (mr *MockInstallerMockRecorder) WriteLocalSystemAgentConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLocalSystemAgentConfig", reflect.TypeOf((*MockInstaller)(nil).WriteLocalSystemAgentConfig), arg0)
+}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -280,6 +280,9 @@ func sendAnnotations(conn *websocket.Conn, reg elementalv1.Registration) error {
 	} else {
 		data["auth"] = reg.Auth
 	}
+	if reg.NoToolkit {
+		data["os.unmanaged"] = "true"
+	}
 	if ipAddress, err := getLocalIPAddress(conn); err != nil {
 		log.Errorf("retrieving the local IP address: %w", err)
 	} else {


### PR DESCRIPTION
Currently the sytem-agent-config is only generated as part of the cloudInitConfigs when installing, but when registering a pre-installed host it is useful to have the option to generate the system-agent-config without install.

This allows us for example to register a pre-installed SLEMicro host via a combustion script which installs then runs elemental-register without the `--install` flag, e.g I've been testing on a VM as below to prove the host registers and shows up in `MachineInventories` without and additional configuration

```
elemental-register --config-path /tmp/elemental-config.yaml --state-path=/tmp/elemental-state.yaml --emulate-tpm --install-local-agent-config --emulated-tpm-seed N
```


