### PR TITLE
Ensure Elemental registration data includes the registration URL

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -287,7 +287,11 @@ func (r *SeedImageReconciler) reconcileConfigMapObject(ctx context.Context, seed
 
 	podConfigMap := &corev1.ConfigMap{}
 
-	regClientConf := mRegistration.GetClientRegistrationConfig(util.GetRancherCACert(ctx, r))
+	regClientConf, err := mRegistration.GetClientRegistrationConfig(util.GetRancherCACert(ctx, r))
+	if err != nil {
+		return fmt.Errorf("failed processing registration config: %w", err)
+	}
+
 	regData, err := yaml.Marshal(regClientConf)
 	if err != nil {
 		return fmt.Errorf("failed marshalling registration config: %w", err)

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -159,6 +159,10 @@ func (i *InventoryServer) writeMachineInventoryCloudConfig(conn *websocket.Conn,
 		registration.Spec.Config = &elementalv1.Config{}
 	}
 
+	if registration.Status.RegistrationURL == "" {
+		return fmt.Errorf("registration URL is not set")
+	}
+
 	elementalConf := elementalv1.Elemental{
 		Registration: elementalv1.Registration{
 			URL:    registration.Status.RegistrationURL,

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -458,6 +458,13 @@ func TestRegistrationMsgGet(t *testing.T) {
 			wantRawResponse: false,
 			wantMessageType: register.MsgError,
 		},
+		{
+			name:            "returns MsgError if mregistration status has no URL",
+			machineName:     "machine-3",
+			protoVersion:    register.MsgError,
+			wantRawResponse: false,
+			wantMessageType: register.MsgError,
+		},
 	}
 
 	server := NewInventoryServer(&FakeAuthServer{})
@@ -473,6 +480,7 @@ func TestRegistrationMsgGet(t *testing.T) {
 			ServiceAccountRef: &v1.ObjectReference{
 				Name: "test-account",
 			},
+			RegistrationURL:   "https://example.machine-1.org",
 			RegistrationToken: "machine-1",
 			Conditions: []metav1.Condition{
 				{
@@ -494,7 +502,29 @@ func TestRegistrationMsgGet(t *testing.T) {
 			ServiceAccountRef: &v1.ObjectReference{
 				Name: "test-account",
 			},
+			RegistrationURL:   "https://example.machine-2.org",
 			RegistrationToken: "machine-2",
+			Conditions: []metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: "True",
+				},
+			},
+		},
+	})
+
+	server.Client.Create(context.Background(), &elementalv1.MachineRegistration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "machine-3",
+		},
+		Spec: elementalv1.MachineRegistrationSpec{
+			MachineName: "machine-3",
+		},
+		Status: elementalv1.MachineRegistrationStatus{
+			ServiceAccountRef: &v1.ObjectReference{
+				Name: "test-account",
+			},
+			RegistrationToken: "machine-3",
 			Conditions: []metav1.Condition{
 				{
 					Type:   "Ready",

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -84,6 +84,14 @@ func TestUnauthenticatedResponse(t *testing.T) {
 		registration := elementalv1.MachineRegistration{}
 		registration.Spec.Config = test.config
 		registration.Status.RegistrationURL = test.regUrl
+		registration.Status.Conditions = []metav1.Condition{
+			{
+				Type:               elementalv1.ReadyCondition,
+				Reason:             elementalv1.SuccessfullyCreatedReason,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+			},
+		}
 
 		buffer := new(bytes.Buffer)
 


### PR DESCRIPTION
This PR ensures it is not possible to generate the registration configuration yaml without a registration URL. It prevents the creation of an ISO without the registration URL, it just errors out instead giving a chance to properly debug it at the right time.

Related to rancher/rancher#42591