### PR TITLE
elemental-airgap: add support to OS images

### DIFF
--- a/scripts/elemental-airgap.sh
+++ b/scripts/elemental-airgap.sh
@@ -2,10 +2,13 @@
 
 set -e
 set -o pipefail
+set -o nounset
 
 # global vars
 CHART_NAME_OPERATOR=""
 ELEMENTAL_OPERATOR_CRDS_CHART_NAME="\$ELEMENTAL_CRDS_CHART"
+CHANNEL_IMAGE_URL=""
+IMAGES_TO_SAVE=""
 
 : ${CONTAINER_IMAGES_NAME:="elemental-image"}
 : ${CONTAINER_IMAGES_FILE:=$CONTAINER_IMAGES_NAME".txt"}
@@ -14,14 +17,15 @@ ELEMENTAL_OPERATOR_CRDS_CHART_NAME="\$ELEMENTAL_CRDS_CHART"
 : ${LOCAL_REGISTRY:=\$LOCAL_REGISTRY}
 : ${CHART_NAME_CRDS:=$ELEMENTAL_OPERATOR_CRDS_CHART_NAME}
 : ${CHART_VERSION:="latest"}
+: ${CHANNEL_IMAGE_NAME:="elemental/os-channel"}
 
 print_help() {
     cat <<- EOF
-Usage: $0 [OPTION] ELEMENTAL_OPERATOR_CHART
+Usage: $0  [OPTION]  -r LOCAL_REGISTRY  ELEMENTAL_OPERATOR_CHART
     [-l|--image-list path] generated text file with the list of saved images (one image per line).
     [-i|--images path] tar.gz gernerated by docker save.
     [-c|--crds-chart] Elemental CRDS chart (if URL, will be downloaded).
-    [-cv|--chart-version] Specify the chart version (only used if passing chart as urls).
+    [-cv|--chart-version] Specify the chart version (only used if passing chart as URLs).
     [-r|--local-registry] registry where to load the images to (used in the next steps).
     [-d|--debug] enable debug output on screen.
     [-h|--help] Usage message.
@@ -37,20 +41,21 @@ Usage: $0 [OPTION] ELEMENTAL_OPERATOR_CHART
     LOCAL_REGISTRY (-r)             : $LOCAL_REGISTRY
     CHART_NAME_CRDS (-c)            : $CHART_NAME_CRDS
     CHART_VERSION (-cv)             : $CHART_VERSION
+    CHANNEL_IMAGE_NAME              : $CHANNEL_IMAGE_NAME
 
     examples:
 
-    $0 staging
+    $0 -r $LOCAL_REGISTRY staging
 
     $0 oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-chart \\
       -c oci://registry.opensuse.org/isv/rancher/elemental/staging/charts/rancher/elemental-operator-crds-chart \\
-      -r LOCAL_AIRGAPPED_REGISTRY
+      -r $LOCAL_REGISTRY
 EOF
 }
 
 parse_parameters() {
 
-    local help
+    local help="false"
 
     POSITIONAL=()
     while [[ $# -gt 0 ]]; do
@@ -105,6 +110,11 @@ parse_parameters() {
         echo ""
         exit_error "ELEMENTAL_OPERATOR_CHART is a required argument"
     fi
+    if [ "$LOCAL_REGISTRY" = "\$LOCAL_REGISTRY" ]; then
+        print_help
+        echo ""
+        exit_error "LOCAL_REGISTRY is required"
+    fi
     case "$CHART_NAME_OPERATOR" in
         Dev|dev|DEV)
         CHART_NAME_OPERATOR="oci://registry.opensuse.org/isv/rancher/elemental/dev/charts/rancher/elemental-operator-chart"
@@ -133,7 +143,7 @@ exit_error() {
 
 log_debug() {
     [ "$DEBUG" = "false" ] && return
-    eval msg=\"$1\"
+    eval msg=\'${1}\'
     echo -e "$msg"
 }
 
@@ -154,9 +164,55 @@ get_chart_val() {
     eval log_debug \"extracted $local_var\\t: \$$local_var\ \($local_val\)\"
 }
 
+# get_json_val "VARNAME" "JSONDATA" "JSONFIELD"
+# receives a json data snippet as JSONDATA and the json field to retrieve as JSONFIELD.
+# puts the value extracted in a variable called as VARNAME.
+get_json_val() {
+    local local_var="$1"
+    local jsondata="$2"
+    local local_val="$3"
+
+    eval $local_var=$(echo $jsondata | jq $local_val)
+    eval log_debug \"extracted $local_var\\t: \$$local_var\ \($local_val\)\"
+}
+
+# set_json_val "VARNAME" "JSONDATA" "JSONFIELD" "VALUE"
+# sets JSONFIELD to VALUE in the received JSONDATA json snippet and outputs the changed json data in
+# variable VARNAME
+set_json_val() {
+    local local_var="$1"
+    local jsondata="$2"
+    local json_field="$3"
+    local local_val="$4"
+
+    log_debug "set $json_field to $local_val"
+    eval $local_var=\'$(echo $jsondata | jq $json_field=\"$local_val\")\'
+    eval log_debug \"\$$local_var\"
+}
+
+# add_image_to_export_list
+# this just adds the passed image to the list of the images to be saved in the images list text file and
+# in the tar.gz archive containing the saved images to be loaded in the local registry.
+add_image_to_export_list() {
+    local img="${1}"
+    if [ -z "${img}" ]; then
+        log_debug "cannot add image to export list: empty image passed"
+        return
+    fi
+    case "${IMAGES_TO_SAVE} " in
+        *" ${img} "*)
+        log_debug "skip adding image to export list: '$img' already added"
+        ;;
+        *)
+        log_debug "mark '$img' image for export"
+        IMAGES_TO_SAVE="$IMAGES_TO_SAVE $img"
+        ;;
+    esac
+}
+
 prereq_checks() {
     log_debug "Check required binaries availability"
-    for cmd in helm yq sed docker; do
+    for cmd in helm yq jq sed docker; do
         if ! command -v "$cmd" > /dev/null; then
             exit_error "'$cmd' not found."
         fi
@@ -170,9 +226,10 @@ fetch_charts() {
     [ "$CHART_NAME_CRDS" != "$ELEMENTAL_OPERATOR_CRDS_CHART_NAME" ] && charts="${charts} CHART_NAME_CRDS"
 
     for c in $charts; do
-        local chart chart_ver
+        local chart=""
+        local chart_ver=""
 
-        # helm pull only supports smever tags: for the "latest" tag just don't put the version.
+        # helm pull only supports semver tags: for the "latest" tag just don't put the version.
         [ "$CHART_VERSION" != "latest" ] && chart_ver="--version $CHART_VERSION"
 
         # 'c' var holds the name (e.g., CHART_NAME_OPERATOR),
@@ -195,46 +252,127 @@ fetch_charts() {
     done
 }
 
-write_elemental_images_file() {
-    local oprtimg_repo oprtimg_tag seedimg_repo seedimg_tag
+pull_chart_container_images() {
+    local oprtimg_repo oprtimg_tag seedimg_repo seedimg_tag registry_url
 
     get_chart_val oprtimg_repo "image.repository"
     get_chart_val oprtimg_tag "image.tag"
     get_chart_val seedimg_repo "seedImage.repository"
     get_chart_val seedimg_tag "seedImage.tag"
-
-    log_info "Creating $CONTAINER_IMAGES_FILE"
-    cat <<- EOF > $CONTAINER_IMAGES_FILE
-${oprtimg_repo}:${oprtimg_tag}
-${seedimg_repo}:${seedimg_tag}
-EOF
-
-    sort -u $CONTAINER_IMAGES_FILE -o $CONTAINER_IMAGES_FILE
-}
-
-pull_images() {
-    local registry_url
     get_chart_val source_registry "registryUrl"
 
-    pulled=""
+    for img in "${oprtimg_repo}:${oprtimg_tag}" "${seedimg_repo}:${seedimg_tag}"; do
+        [ -z "$img" ] && continue
 
-    while IFS= read -r i; do
-        [ -z "${i}" ] && continue
-        i="${source_registry}/${i}"
-        if docker pull "${i}" > /dev/null 2>&1; then
-            log_info "Image pull success: ${i}"
-            pulled="${pulled} ${i}"
-        else
-            if docker inspect "${i}" > /dev/null 2>&1; then
-                pulled="${pulled} ${i}"
-            else
-                log_info "Image pull failed: ${i}"
-            fi
+        img="${source_registry}/${img}"
+        if pull_image "${img}"; then
+            add_image_to_export_list "${img}"
         fi
-    done < "${CONTAINER_IMAGES_FILE}"
+    done
+}
 
-    log_info "Creating ${CONTAINER_IMAGES_ARCHIVE} with $(echo ${pulled} | wc -w | tr -d '[:space:]') images"
-    docker save $(echo ${pulled}) | gzip --stdout > ${CONTAINER_IMAGES_ARCHIVE}
+pull_image() {
+    local image_url="$1"
+
+    [ -z "$image_url" ] && return 1
+    if docker pull "$image_url" > /dev/null 2>&1; then
+        log_info "Image pull success: ${image_url}"
+    else
+        if docker inspect "$image_url" > /dev/null 2>&1; then
+            log_debug "error downloading ${image_url} but the image is saved"
+        else
+            log_info "Image pull failed: ${image_url}"
+            return 1
+        fi
+    fi
+    return 0
+}
+
+
+build_os_channel() {
+    local channel_img
+    local channel_tag
+    local channel_repo
+
+    log_info "Creating OS channel"
+    get_chart_val channel_img "channel.repository"
+    get_chart_val channel_tag "channel.tag"
+    get_chart_val channel_repo "registryUrl"
+
+    if [ -z "$channel_img" -o -z "$channel_tag" ]; then
+        log_info "\nWARNING: channel image not found: you will need to provide your own Elemental OS images\n"
+        return
+    fi
+    log_info "Found channel image: ${channel_repo}/${channel_img}:${channel_tag}"
+
+    TEMPDIR=$(mktemp -d)
+    log_debug "build channel image in $TEMPDIR"
+    pushd $TEMPDIR
+    # extract the channel.json
+    if ! docker run --entrypoint cat ${channel_repo}/${channel_img}:${channel_tag} channel.json > channel.json; then
+        exit_error "cannot extract OS images"
+    fi
+
+    # write the new channel and identify OS images to save
+    local new_channel=""
+    for i in $(seq 0 20); do
+        local item item_type item_image item_name
+        item=$(jq .[$i] channel.json)
+        [ "$item" = "null" ] && break
+
+        get_json_val item_name "$item" ".metadata.name"
+        get_json_val item_type "$item" ".spec.type"
+        get_json_val item_image "$item" ".spec.metadata.upgradeImage"
+        get_json_val item_display "$item" ".spec.metadata.displayName"
+
+        # drop the items in the channel which are not containers
+        if [ "$item_type" != "container" ]; then
+            log_debug "skip OS $item_type entry:\t$item_name\t$item_image"
+            continue
+        fi
+
+        log_info "Extract OS image:\n\t$item_name ($item_display)\n\t$item_image"
+
+        # save the OS image
+        if pull_image "${item_image}"; then
+            add_image_to_export_list "${item_image}"
+
+            # prepend the private registry name
+            set_json_val item "$item" ".spec.metadata.upgradeImage" "$LOCAL_REGISTRY/$item_image"
+
+            [ -z "$new_channel" ] && new_channel="[$item" || new_channel="$new_channel,$item"
+        fi
+    done
+    new_channel="$new_channel]"
+
+    # create the new channel container image targeting the private registry
+    CHANNEL_IMAGE_URL="${CHANNEL_IMAGE_NAME}:${channel_tag}"
+    log_info "Create new channel image for the private registry: ${CHANNEL_IMAGE_URL}"
+    jq -n "$new_channel" > channel.json
+    cat << EOF > Dockerfile
+FROM registry.suse.com/bci/bci-busybox:latest
+ADD channel.json /channel.json
+USER 10010:10010
+ENTRYPOINT ["busybox", "cp"]
+CMD ["/channel.json", "/data/output"]
+EOF
+    docker build . -t ${CHANNEL_IMAGE_URL}
+    popd
+    [ "$DEBUG" = "false" ] && rm -rf $TEMPDIR
+
+    add_image_to_export_list "${CHANNEL_IMAGE_URL}"
+}
+
+create_container_images_archive() {
+    log_info "Creating ${CONTAINER_IMAGES_ARCHIVE} with $(echo ${IMAGES_TO_SAVE} | wc -w | tr -d '[:space:]') images"
+    echo -n "" > "${CONTAINER_IMAGES_FILE}"
+    for i in ${IMAGES_TO_SAVE} ; do
+        log_debug "* $i"
+        echo "$i" >> "${CONTAINER_IMAGES_FILE}"
+    done
+    sort -u ${CONTAINER_IMAGES_FILE} -o ${CONTAINER_IMAGES_FILE}
+
+    docker save $(echo ${IMAGES_TO_SAVE}) | gzip --stdout > ${CONTAINER_IMAGES_ARCHIVE}
 }
 
 print_next_steps() {
@@ -255,13 +393,14 @@ NEXT STEPS:
    --images $CONTAINER_IMAGES_ARCHIVE \\
    --registry $LOCAL_REGISTRY
 
-2) Install the elemental charts downloaded in the current directory passing the local registry:
+2) Install the elemental charts downloaded in the current directory passing the local registry
+   and the newly created channel image:
 
 helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator-crds $CHART_NAME_CRDS
 
 helm upgrade --create-namespace -n cattle-elemental-system --install elemental-operator $CHART_NAME_OPERATOR \\
   --set registryUrl=$LOCAL_REGISTRY \\
-  --set channel.repository=""
+  --set channel.repository="$CHANNEL_IMAGE_URL"
 
 EOF
 }
@@ -272,8 +411,11 @@ prereq_checks
 
 fetch_charts
 
-write_elemental_images_file
+pull_chart_container_images
 
-pull_images
+build_os_channel
+
+create_container_images_archive
 
 print_next_steps
+


### PR DESCRIPTION
Allow to extract and download the OS images specified in the channel image shipped with the Elemental Operator chart.
Build a new channel image targeting the local registry of the airgapped scenario (which is now a mandatory option).

Fixes https://github.com/rancher/elemental/issues/950