### PR TITLE
make verify: stay on mockgen v0.2.0

### DIFF
--- a/scripts/generate_mocks.sh
+++ b/scripts/generate_mocks.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-go install go.uber.org/mock/mockgen@latest
+go install go.uber.org/mock/mockgen@v0.2.0
 
 # Always create mock files into a "mocks" subfolder to be ignored in test coverage.
 # See codecov.yml for more info 


### PR DESCRIPTION
latest, version v0.3.0, causes generate_mocks.sh to fail. Stay on v0.2.0 for now.

Fixes #522 