### PR TITLE
Prevent recalling bootstrap.sh on 'systemctl restart elemental-system-agent'

### DIFF
--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -466,12 +466,7 @@ func (r *MachineInventorySelectorReconciler) newBootstrapPlan(ctx context.Contex
 			},
 			{
 				CommonInstruction: applyinator.CommonInstruction{
-					Command: "/var/lib/rancher/bootstrap.sh",
-					// Ensure local plans will be enabled, this is required to ensure the local
-					// plan stopping elemental-system-agent is executed
-					Env: []string{
-						"CATTLE_LOCAL_ENABLED=true",
-					},
+					Command: "bash -c '[ -f /var/lib/rancher/bootstrap_done ] || /var/lib/rancher/bootstrap.sh && touch /var/lib/rancher/bootstrap_done'",
 				},
 			},
 		},

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -466,7 +466,10 @@ func (r *MachineInventorySelectorReconciler) newBootstrapPlan(ctx context.Contex
 			},
 			{
 				CommonInstruction: applyinator.CommonInstruction{
-					Command: "bash -c '[ -f /var/lib/rancher/bootstrap_done ] || /var/lib/rancher/bootstrap.sh && touch /var/lib/rancher/bootstrap_done'",
+					Command: "bash",
+					Args: []string{
+						"-c", "[ -f /var/lib/rancher/bootstrap_done ] || /var/lib/rancher/bootstrap.sh && touch /var/lib/rancher/bootstrap_done",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
One time instructions are always re-applied at system-agent start which triggers rancher provisioning even if the node was already provisioned. This PR prevents re applying bootstrap.sh script if was already successfully applied in the past.

related to rancher/system-agent#126