### PR TITLE
Improve update events filtering to actually ignore status updates

### DIFF
--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -521,11 +521,13 @@ func (r *MachineInventoryReconciler) ignoreIncrementalStatusUpdate() predicate.F
 				oldMInventory = oldMInventory.DeepCopy()
 				newMInventory := e.ObjectNew.(*elementalv1.MachineInventory).DeepCopy()
 
+				// Ignore all fields that might be updated on a status update
 				oldMInventory.Status = elementalv1.MachineInventoryStatus{}
 				newMInventory.Status = elementalv1.MachineInventoryStatus{}
-
 				oldMInventory.ObjectMeta.ResourceVersion = ""
 				newMInventory.ObjectMeta.ResourceVersion = ""
+				oldMInventory.ManagedFields = []metav1.ManagedFieldsEntry{}
+				newMInventory.ManagedFields = []metav1.ManagedFieldsEntry{}
 
 				update := !cmp.Equal(oldMInventory, newMInventory)
 				if !update {

--- a/controllers/machineregistration_controller.go
+++ b/controllers/machineregistration_controller.go
@@ -325,10 +325,13 @@ func (r *MachineRegistrationReconciler) ignoreIncrementalStatusUpdate() predicat
 				oldMRegistration = oldMRegistration.DeepCopy()
 				newMregistration := e.ObjectNew.(*elementalv1.MachineRegistration).DeepCopy()
 
+				// Ignore all fields that might be updated on a status update
 				oldMRegistration.Status = elementalv1.MachineRegistrationStatus{}
 				newMregistration.Status = elementalv1.MachineRegistrationStatus{}
 				oldMRegistration.ObjectMeta.ResourceVersion = ""
 				newMregistration.ObjectMeta.ResourceVersion = ""
+				oldMRegistration.ManagedFields = []metav1.ManagedFieldsEntry{}
+				newMregistration.ManagedFields = []metav1.ManagedFieldsEntry{}
 
 				update := !cmp.Equal(oldMRegistration, newMregistration)
 				if !update {

--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -572,10 +572,13 @@ func filterSelectorUpdateEvents() predicate.Funcs {
 				oldS = oldS.DeepCopy()
 				newS := e.ObjectNew.(*elementalv1.MachineInventorySelector).DeepCopy()
 
+				// Ignore all fields that might be updated on a status update
 				oldS.Status = elementalv1.MachineInventorySelectorStatus{}
 				newS.Status = elementalv1.MachineInventorySelectorStatus{}
 				oldS.ObjectMeta.ResourceVersion = ""
 				newS.ObjectMeta.ResourceVersion = ""
+				oldS.ManagedFields = []metav1.ManagedFieldsEntry{}
+				newS.ManagedFields = []metav1.ManagedFieldsEntry{}
 
 				update := !cmp.Equal(oldS, newS)
 				if !update {


### PR DESCRIPTION
On status patch managed fields are also updated, hence the comparison done always sees a difference even if there was only an status update.