### PR TITLE
Patch already existing versions on channel sync

### DIFF
--- a/api/v1beta1/common_consts.go
+++ b/api/v1beta1/common_consts.go
@@ -20,6 +20,9 @@ const (
 	// ElementalManagedLabel label used to put on resources managed by the elemental operator.
 	ElementalManagedLabel = "elemental.cattle.io/managed"
 
+	// ElementalManagedLabel label used to put on resources managed by the elemental operator.
+	ElementalManagedOSVersionChannelLabel = "elemental.cattle.io/channel"
+
 	// SASecretSuffix is the suffix used to name registration service account's token secret
 	SASecretSuffix = "-token"
 

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -56,10 +56,10 @@ const updatedJSON = `[
       "name": "v0.1.0"
     },
     "spec": {
-      "version": "v0.1.0",
+      "version": "v0.1.0-patched",
       "type": "container",
       "metadata": {
-        "upgradeImage": "foo/bar:v0.1.0"
+        "upgradeImage": "foo/bar:v0.1.0-patched"
       }
     }
   },
@@ -575,5 +575,12 @@ var _ = Describe("managed os version channel controller integration tests", func
 			}, managedOSVersion)
 			return err == nil
 		}, 4*time.Second, 1*time.Second).Should(BeTrue())
+
+		// After channel update already existing versions were patched
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Name:      "v0.1.0",
+			Namespace: ch.Namespace,
+		}, managedOSVersion)).To(Succeed())
+		Expect(managedOSVersion.Spec.Version).To(Equal("v0.1.0-patched"))
 	})
 })


### PR DESCRIPTION
This PR adds am owner label to the managedOSVersions created by a channel. This allows to easily fetch owned versions later on for a given channel. Having a map of owned versions allows to easily patch already existing versions.

Note this PR does not apply the label to already existing versions, I have not considered this case for simplicity and because the workaround is as simple as deleting the versions and re-sync again, or deleting and recreating channels. More over this is not a regression in any case.

Deleting ManagedOSVersions is not implemented as I am not sure we have a clear criteria to do so. In any case most of the logic is already there and it could be easily added later on if required.

Fixes #513 