### PR TITLE
Prevent installing if previous CRDs are pending to be removed

### DIFF
--- a/charts/crds/templates/validate-no-pending-deletions.yaml
+++ b/charts/crds/templates/validate-no-pending-deletions.yaml
@@ -1,0 +1,6 @@
+{{- $inventoryCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" .Release.Namespace "machineinventories.elemental.cattle.io" -}}
+{{- if $inventoryCRD -}}
+  {{- if $inventoryCRD.metadata.deletionTimestamp -}}
+     {{- required "CRDs from previous installations are pending to be removed (deletionTimestamp is set). Fully deleting them before (re-)installing is required" "" -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
This PR checks there are no previous CRDs having a deletion time stamp set. If so it assumes these are leftovers of previous installations and refuses to install the crds chart.

For the time being it only checks on machineinventories, however it could be expanded if we consider that necessary. For now I'd keep the check to the minimum.

When trying to install crds chart if the machine inventory is already there with a deletionTimestamp set produces an error like the following:

```bash
$ helm upgrade --install -n cattle-elemental-system --create-namespace \
    elemental-operator-crds \
    oci://registry.opensuse.org/isv/rancher/elemental/pr/rancher/elemental-operator/pr-553/charts/rancher/elemental-operator-crds-chart                                                                                                                                                                                                                            
Release "elemental-operator-crds" does not exist. Installing it now.                                                                                                                                                                               
Pulled: registry.opensuse.org/isv/rancher/elemental/pr/rancher/elemental-operator/pr-553/charts/rancher/elemental-operator-crds-chart:1.4.0                                                                                                        
Digest: sha256:263aa9a6d54990923ea92aa3c6f8eb1bad4550545d45981cd043087a964d9c52                                                                                                                                                                    
Error: execution error at (elemental-operator-crds/templates/validate-no-pending-deletions.yaml:4:9): CRDs from previous installations are pending to be removed (deletionTimestamp is set). Fully deleting them before (re-)installing is required
```

In the particular case of #515 to fully clear the offending resource it can be done by removing the finalizers of any MachineInventory resource:

```bash
$ kubectl patch machineinventory <machineInventoryName> -n fleet-default --type merge \
    -p '{"metadata": {"finalizers": []}}'
```

Fixes #515