### PR TITLE
Charts: change names to align to Rancher guidelines

### DIFF
--- a/.obs/chartfile/crds/Chart.yaml
+++ b/.obs/chartfile/crds/Chart.yaml
@@ -3,7 +3,7 @@
 #!BuildTag: rancher/elemental-operator-crds-chart:%VERSION%
 #!BuildTag: rancher/elemental-operator-crds-chart:%VERSION%-%RELEASE%
 apiVersion: v2
-name: elemental-operator-crds
+name: elemental-crd
 description: A Helm chart for deploying Rancher Elemental Operator CRDs
 version: "%VERSION%"
 appVersion: "%VERSION%"

--- a/.obs/chartfile/operator/Chart.yaml
+++ b/.obs/chartfile/operator/Chart.yaml
@@ -3,8 +3,8 @@
 #!BuildTag: rancher/elemental-operator-chart:%VERSION%
 #!BuildTag: rancher/elemental-operator-chart:%VERSION%-%RELEASE%
 apiVersion: v2
-name: elemental-operator
-description: Rancher Elemental Operator
+name: elemental
+description: Elemental provides Cloud Native OS Management for Cluster Nodes.
 icon: https://raw.githubusercontent.com/rancher/elemental/main/logo/icon-elemental.svg
 version: "%VERSION%"
 appVersion: "%VERSION%"
@@ -12,12 +12,12 @@ annotations:
   catalog.cattle.io/auto-install: elemental-crd=match
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Elemental
-  catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.28.0-0'
+  catalog.cattle.io/kube-version: '>= 1.23.0-0'
   catalog.cattle.io/namespace: cattle-elemental-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux
   catalog.cattle.io/provides-gvr: elemental.cattle.io/v1beta1
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.7.0-0'
   catalog.cattle.io/release-name: elemental-operator
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool

--- a/charts/crds/Chart.yaml
+++ b/charts/crds/Chart.yaml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
-name: elemental-operator-crds
+name: elemental-crd
 description: A Helm chart for deploying Rancher Elemental Operator CRDs
 version: 0.0.0
 appVersion: 0.0.0

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
-name: elemental-operator
-description: Rancher Elemental Operator
+name: elemental
+description: Elemental provides Cloud Native OS Management for Cluster Nodes.
 icon: https://raw.githubusercontent.com/rancher/elemental/main/logo/icon-elemental.svg
 version: 0.0.0
 appVersion: 0.0.0
@@ -9,12 +9,12 @@ annotations:
   catalog.cattle.io/auto-install: elemental-crd=match
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Elemental
-  catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.28.0-0'
+  catalog.cattle.io/kube-version: '>= 1.23.0-0'
   catalog.cattle.io/namespace: cattle-elemental-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux
   catalog.cattle.io/provides-gvr: elemental.cattle.io/v1beta1
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.7.0-0'
   catalog.cattle.io/release-name: elemental-operator
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool


### PR DESCRIPTION
In rancher/charts the main chart for a project carry just the name of the project (`<project>`) and the CRDs chart is named `<project>-crd`.
Till now we have kept different names here on github, i.e., `elemental-operator` and `elemental-operator-crds`.

At this point we are relasing the charts in 3 different places (actually 4 if we count IBS too... but let's just forget that!):
1) in OBS
2) in rancher/charts
3) on gh-pages repo on github

This commit aligns the chart names to the rancher/charts style everywhere.
While I would strongly push the change on our github release, I'm not that strongly opinionated to change also the naming on OBS/IBS (we could keep current naming there). For this reason, OBS changes are in a separate commit.

Fixes #562 