### PR TITLE
Add grub package to seedimage built in OBS

### DIFF
--- a/.obs/dockerfile/seedimage/Dockerfile
+++ b/.obs/dockerfile/seedimage/Dockerfile
@@ -10,7 +10,7 @@ ARG SLE_VERSION
 FROM suse/sle15:$SLE_VERSION as BASE
 
 RUN  mkdir -p /installroot && \
-    zypper --gpg-auto-import-keys --installroot /installroot in -y --no-recommends elemental-toolkit elemental-httpfy xorriso curl coreutils ca-certificates ca-certificates-mozilla gptfdisk squashfs util-linux dosfstools mtools e2fsprogs
+    zypper --gpg-auto-import-keys --installroot /installroot in -y --no-recommends elemental-toolkit elemental-httpfy xorriso curl coreutils ca-certificates ca-certificates-mozilla gptfdisk squashfs util-linux dosfstools mtools e2fsprogs grub2
 
 
 FROM scratch as SEEDIMAGE_BUILDER


### PR DESCRIPTION
Getting the following error when building a raw disk image using a seedimage-builder from dev:

```
DEBU[2023-11-23T14:06:30Z] Running cmd: 'grub2-editenv /iso/build/oem/grubenv set next_entry=recovery'
ERRO[2023-11-23T14:06:30Z] Error running command: exec: "grub2-editenv": executable file not found in $PATH
ERRO[2023-11-23T14:06:30Z] Failed setting grub variables:
ERRO[2023-11-23T14:06:30Z] failed setting firstboot menu entry: exec: "grub2-editenv": executable file not found in $PATH
ERRO[2023-11-23T14:06:30Z] Woophs, something went terribly wrong: 1 error occurred:
        * exec: "grub2-editenv": executable file not found in $PATH
```