### PR TITLE
Fix device-selector logic

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -146,17 +146,17 @@ func (i *installer) findInstallationDevice(selector elementalv1.DeviceSelector) 
 			}
 
 			if !matches {
-				log.Debug("%s does not match selector %s", disk.Name, sel.Key)
+				log.Debugf("%s does not match selector %s", disk.Name, sel.Key)
 				delete(devices, disk.Name)
 				break
 			}
 		}
 	}
 
-	log.Debug("%s disks matching selector", len(devices))
+	log.Debugf("%s disks matching selector", len(devices))
 
 	for _, dev := range devices {
-		return dev.Name, nil
+		return fmt.Sprintf("/dev/%s", dev.Name), nil
 	}
 
 	return "", fmt.Errorf("no device found matching selector")
@@ -183,7 +183,7 @@ func matchesIn(disk *block.Disk, req elementalv1.DeviceSelectorRequirement) (boo
 	}
 
 	for _, val := range req.Values {
-		if val == disk.Name {
+		if val == disk.Name || val == fmt.Sprintf("/dev/%s", disk.Name) {
 			return true, nil
 		}
 	}

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -140,7 +140,7 @@ var _ = Describe("installer pick device", Label("installer", "install", "device"
 		install = &installer{
 			fs:     fs,
 			runner: cliRunner,
-			disks:  []*ghw.Disk{{Name: "/dev/pickme"}},
+			disks:  []*ghw.Disk{{Name: "pickme"}},
 		}
 		actualDevice, err := install.findInstallationDevice(elementalv1.DeviceSelector{})
 		Expect(err).ToNot(HaveOccurred())
@@ -151,13 +151,13 @@ var _ = Describe("installer pick device", Label("installer", "install", "device"
 			fs:     fs,
 			runner: cliRunner,
 			disks: []*ghw.Disk{
-				{Name: "/dev/sda"},
-				{Name: "/dev/sdb"},
-				{Name: "/dev/sdc"},
-				{Name: "/dev/sdd"},
-				{Name: "/dev/sde"},
-				{Name: "/dev/sdf"},
-				{Name: "/dev/sdg"},
+				{Name: "sda"},
+				{Name: "sdb"},
+				{Name: "sdc"},
+				{Name: "sdd"},
+				{Name: "sde"},
+				{Name: "sdf"},
+				{Name: "sdg"},
 			},
 		}
 		selector := elementalv1.DeviceSelector{
@@ -177,8 +177,8 @@ var _ = Describe("installer pick device", Label("installer", "install", "device"
 			fs:     fs,
 			runner: cliRunner,
 			disks: []*ghw.Disk{
-				{Name: "/dev/sda", SizeBytes: 85899345920},
-				{Name: "/dev/sdb", SizeBytes: 214748364800},
+				{Name: "sda", SizeBytes: 85899345920},
+				{Name: "sdb", SizeBytes: 214748364800},
 			},
 		}
 		selector := elementalv1.DeviceSelector{
@@ -198,8 +198,8 @@ var _ = Describe("installer pick device", Label("installer", "install", "device"
 			fs:     fs,
 			runner: cliRunner,
 			disks: []*ghw.Disk{
-				{Name: "/dev/sda", SizeBytes: 85899345920},
-				{Name: "/dev/sdb", SizeBytes: 214748364800},
+				{Name: "sda", SizeBytes: 85899345920},
+				{Name: "sdb", SizeBytes: 214748364800},
 			},
 		}
 		selector := elementalv1.DeviceSelector{
@@ -219,8 +219,8 @@ var _ = Describe("installer pick device", Label("installer", "install", "device"
 			fs:     fs,
 			runner: cliRunner,
 			disks: []*ghw.Disk{
-				{Name: "/dev/sda"},
-				{Name: "/dev/sdb"},
+				{Name: "sda"},
+				{Name: "sdb"},
 			},
 		}
 		selector := elementalv1.DeviceSelector{


### PR DESCRIPTION
disk.Name only contains name, not path (eg sda not /dev/sda).

This commit fixes the logic so users can specify either the name or path and elemental will install to the correct device.