### PR TITLE
Add TargetPlatform to SeedImageSpec

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -2674,8 +2674,9 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               targetPlatform:
-                description: Platform specifies the target platform to build the seedimage
-                  for.
+                description: 'Platform specifies the target platform for the built
+                  image. Example: linux/amd64'
+                pattern: ^$|^\S+\/\S+$
                 type: string
               type:
                 default: iso

--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -2673,6 +2673,10 @@ spec:
                   image. Defaults to 6Gi
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              targetPlatform:
+                description: Platform specifies the target platform to build the seedimage
+                  for.
+                type: string
               type:
                 default: iso
                 description: Type specifies the type of seed image to built. Valid

--- a/api/v1beta1/seedimage_type.go
+++ b/api/v1beta1/seedimage_type.go
@@ -54,7 +54,10 @@ type SeedImageSpec struct {
 	// +kubebuilder:validation:Enum=iso;raw
 	// +kubebuilder:default:=iso
 	Type SeedImageType `json:"type"`
-	// Platform specifies the target platform to build the seedimage for.
+	// Platform specifies the target platform for the built image. Example: linux/amd64
+	// +kubebuilder:example=linux/amd64
+	// +kubebuilder:validation:Pattern=`^$|^\S+\/\S+$`
+	// +kubebuilder:validation:Type=string
 	// +optional
 	TargetPlatform Platform `json:"targetPlatform"`
 	// CloudConfig contains cloud-config data to be put in the generated iso.

--- a/api/v1beta1/seedimage_type.go
+++ b/api/v1beta1/seedimage_type.go
@@ -54,12 +54,17 @@ type SeedImageSpec struct {
 	// +kubebuilder:validation:Enum=iso;raw
 	// +kubebuilder:default:=iso
 	Type SeedImageType `json:"type"`
+	// Platform specifies the target platform to build the seedimage for.
+	// +optional
+	TargetPlatform Platform `json:"targetPlatform"`
 	// CloudConfig contains cloud-config data to be put in the generated iso.
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +optional
 	CloudConfig map[string]runtime.RawExtension `json:"cloud-config,omitempty" yaml:"cloud-config,omitempty"`
 }
+
+type Platform string
 
 type SeedImageType string
 

--- a/config/crd/bases/elemental.cattle.io_seedimages.yaml
+++ b/config/crd/bases/elemental.cattle.io_seedimages.yaml
@@ -123,6 +123,10 @@ spec:
                   image. Defaults to 6Gi
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
+              targetPlatform:
+                description: Platform specifies the target platform to build the seedimage
+                  for.
+                type: string
               type:
                 default: iso
                 description: Type specifies the type of seed image to built. Valid

--- a/config/crd/bases/elemental.cattle.io_seedimages.yaml
+++ b/config/crd/bases/elemental.cattle.io_seedimages.yaml
@@ -124,8 +124,9 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               targetPlatform:
-                description: Platform specifies the target platform to build the seedimage
-                  for.
+                description: 'Platform specifies the target platform for the built
+                  image. Example: linux/amd64'
+                pattern: ^$|^\S+\/\S+$
                 type: string
               type:
                 default: iso

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -647,7 +647,26 @@ func defaultInitContainers(seedImg *elementalv1.SeedImage, buildImg string, pull
 }
 
 func defaultRawInitContainers(seedImg *elementalv1.SeedImage, buildImg string, pullPolicy corev1.PullPolicy) []corev1.Container {
-	buildCommands := []string{"/usr/bin/elemental --debug build-disk --unprivileged --expandable --deploy-command elemental-register,--debug,--reset --squash-no-compression --cloud-init /overlay/reg/reset-config.yaml,/overlay/iso-config/cloud-config.yaml -n elemental -o /iso $(ELEMENTAL_BASE_IMAGE)", "mv /iso/elemental.raw /iso/$(ELEMENTAL_OUTPUT_NAME)"}
+	platformArg := ""
+	if seedImg.Spec.TargetPlatform != "" {
+		platformArg = fmt.Sprintf("--platform %s", seedImg.Spec.TargetPlatform)
+	}
+
+	buildCommands := []string{
+		fmt.Sprintf(`/usr/bin/elemental \
+        --debug \
+        build-disk \
+        %s \
+        --unprivileged \
+        --expandable \
+        --deploy-command elemental-register,--debug,--reset \
+        --squash-no-compression \
+        --cloud-init /overlay/reg/reset-config.yaml,/overlay/iso-config/cloud-config.yaml \
+        -n elemental \
+        -o /iso $(ELEMENTAL_BASE_IMAGE)`, platformArg),
+
+		"mv /iso/elemental.raw /iso/$(ELEMENTAL_OUTPUT_NAME)",
+	}
 
 	return []corev1.Container{
 		{


### PR DESCRIPTION
TargetPlatform is used when building raw disk-images for other platforms. An example being building rpi images on a cluster running on x86_64 hardware.