### PR TITLE
Use reset service as raw disk deploy command

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -659,7 +659,7 @@ func defaultRawInitContainers(seedImg *elementalv1.SeedImage, buildImg string, p
         %s \
         --unprivileged \
         --expandable \
-        --deploy-command elemental-register,--debug,--reset \
+        --deploy-command systemctl,start,elemental-register-reset.service \
         --squash-no-compression \
         --cloud-init /overlay/reg/reset-config.yaml,/overlay/iso-config/cloud-config.yaml \
         -n elemental \


### PR DESCRIPTION
This ensures `elemental-register --reset` is run with all needed dependencies satisfied (mainly time-sync for the rpi).