### PR TITLE
Restrict package arch to x86_64 and aarch64

### DIFF
--- a/.obs/specfile/elemental-operator.spec
+++ b/.obs/specfile/elemental-operator.spec
@@ -26,6 +26,9 @@ URL:            https://github.com/rancher/%{name}
 Source:         %{name}-%{version}.tar
 Source1:        %{name}.obsinfo
 
+# go-tpm-tools aren't _that_ portable :-(
+ExclusiveArch:  x86_64 aarch64
+
 BuildRequires:  gcc-c++
 BuildRequires:  glibc-devel
 BuildRequires:  openssl-devel


### PR DESCRIPTION
go-tpm-tools fails to build on other archs, e.g. s390x.

See bsc#1218560