### PR TITLE
Add elemental-seedimage-hooks package

### DIFF
--- a/.obs/dockerfile/seedimage/Dockerfile
+++ b/.obs/dockerfile/seedimage/Dockerfile
@@ -10,7 +10,7 @@ ARG SLE_VERSION
 FROM suse/sle15:$SLE_VERSION as BASE
 
 RUN  mkdir -p /installroot && \
-    zypper --gpg-auto-import-keys --installroot /installroot in -y --no-recommends elemental-toolkit elemental-httpfy xorriso curl coreutils ca-certificates ca-certificates-mozilla gptfdisk squashfs util-linux dosfstools mtools e2fsprogs grub2
+    zypper --gpg-auto-import-keys --installroot /installroot in -y --no-recommends elemental-toolkit elemental-httpfy elemental-seedimage-hooks xorriso curl coreutils ca-certificates ca-certificates-mozilla gptfdisk squashfs util-linux dosfstools mtools e2fsprogs grub2
 
 
 FROM scratch as SEEDIMAGE_BUILDER

--- a/.obs/specfile/elemental-operator.spec
+++ b/.obs/specfile/elemental-operator.spec
@@ -53,6 +53,9 @@ BuildRequires:  compiler(go-compiler) >= 1.20
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
+%define systemdir /system
+%define oemdir %{systemdir}/oem
+
 %package -n elemental-register
 Summary: The registration client
 
@@ -77,6 +80,12 @@ Summary: Simple http server
 
 %description -n elemental-httpfy
 httpfy starts a simple http server, serving files from the current dir.
+
+%package -n elemental-seedimage-hooks
+Summary: Hooks used in SeedImage builder
+
+%description -n elemental-seedimage-hooks
+Hooks used in SeedImage builder to copy firmware when building disk-images.
 
 %prep
 %setup -q -n %{name}-%{version}
@@ -119,6 +128,10 @@ make httpfy
 %{__install} -m 755 build/elemental-support %{buildroot}%{_sbindir}
 %{__install} -m 755 build/elemental-httpfy %{buildroot}%{_sbindir}
 
+# hooks
+mkdir -p %{buildroot}%{oemdir}
+%{__install} -m 755 hooks/*.yaml %{buildroot}%{oemdir}/
+
 %files
 %defattr(-,root,root,-)
 %license LICENSE
@@ -139,5 +152,12 @@ make httpfy
 %defattr(-,root,root,-)
 %license LICENSE
 %{_sbindir}/elemental-httpfy
+
+%files -n elemental-seedimage-hooks
+%defattr(-,root,root,-)
+%license LICENSE
+%dir %{systemdir}
+%dir %{oemdir}
+%{oemdir}/*
 
 %changelog

--- a/hooks/01_rpi-firmware.yaml
+++ b/hooks/01_rpi-firmware.yaml
@@ -1,0 +1,6 @@
+name: "Raspberry Pi post disk hook"
+stages:
+    after-disk:
+    - name: "Copy firmware to EFI partition"
+      commands:
+      - cp -r /iso/build/recovery.img.root/boot/vc/* /iso/build/efi/

--- a/hooks/01_rpi-firmware.yaml
+++ b/hooks/01_rpi-firmware.yaml
@@ -1,6 +1,7 @@
 name: "Raspberry Pi post disk hook"
 stages:
     after-disk:
-    - name: "Copy firmware to EFI partition"
+    - if: '[ -d "/iso/build/recovery.img.root/boot/vc" ]'
+      name: "Copy firmware to EFI partition"
       commands:
       - cp -r /iso/build/recovery.img.root/boot/vc/* /iso/build/efi/


### PR DESCRIPTION
The elemental-seedimage-hooks package contains hooks to copy rpi firmware when building a raw disk image.