### PR TITLE
Add hostname to system-data

### DIFF
--- a/pkg/runtime/info.go
+++ b/pkg/runtime/info.go
@@ -1,0 +1,34 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import "os"
+
+type Info struct {
+	Hostname string `json:"hostname"`
+}
+
+func New() (*Info, error) {
+	name, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Info{
+		Hostname: name,
+	}, nil
+}

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -441,16 +441,17 @@ func updateInventoryFromSMBIOSData(data []byte, mInventory *elementalv1.MachineI
 	// Sanitize any lower dashes into dashes as hostnames cannot have lower dashes, and we use the inventory name
 	// to set the machine hostname. Also set it to lowercase
 	name, err := replaceStringData(smbiosData, mInventory.Name)
-	if err != nil {
+	if err == nil {
+		mInventory.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
+	} else {
 		if errors.Is(err, errValueNotFound) {
-			log.Warningf("Value not found: %v", mInventory.Name)
-			name = "m"
+			// value not found, will be set in updateInventoryFromSystemData
+			log.Warningf("SMBIOS Value not found: %v", mInventory.Name)
 		} else {
 			return err
 		}
 	}
 
-	mInventory.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
 	log.Debugf("Adding labels from registration")
 	// Add extra label info from data coming from smbios and based on the registration data
 	if mInventory.Labels == nil {
@@ -488,6 +489,18 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 	// systemData.Baseboard -> asset, serial, vendor,version,product. Kind of useless?
 	// systemData.Chassis -> asset, serial, vendor,version,product, type. Maybe be useful depending on the provider.
 	// systemData.Topology -> CPU/memory and cache topology. No idea if useful.
+
+	name, err := replaceStringData(labels, inv.Name)
+	if err != nil {
+		if errors.Is(err, errValueNotFound) {
+			log.Warningf("System data value not found: %v", inv.Name)
+			name = "m"
+		} else {
+			return err
+		}
+	}
+
+	inv.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
 
 	log.Debugf("Parsing labels from System Data")
 


### PR DESCRIPTION
Add new `${System Data/Runtime/Hostname}` key to the registration data sent from the elemental-register command.

Fixes #591 