### PR TITLE
hostname: set the hostname on the newer location too

### DIFF
--- a/controllers/machineselector_controller.go
+++ b/controllers/machineselector_controller.go
@@ -451,6 +451,11 @@ func (r *MachineInventorySelectorReconciler) newBootstrapPlan(ctx context.Contex
 				Path:        "/usr/local/etc/hostname",
 				Permissions: "0644",
 			},
+			{
+				Content:     base64.StdEncoding.EncodeToString([]byte(mInventory.Name)),
+				Path:        "/run/elemental/persistent/etc/hostname",
+				Permissions: "0644",
+			},
 		},
 		OneTimeInstructions: []applyinator.OneTimeInstruction{
 			{


### PR DESCRIPTION
The /etc/hostname file is a symlink file re-created at every elemental boot. The symlink used to point to /usr/local/etc/hostname. For forthcoming images, the symlink will point to
/run/elemental/persistent/etc/hostname.
Let's stay on the safe side: let's update the hostname at that location too.

Fixes #601 