### PR TITLE
Bump github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -25,17 +25,20 @@ jobs:
       - name: Build
         run: make build
       - name: Store operator binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elemental-operator
           path: build/elemental-operator
+          overwrite: true
       - name: Store register binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elemental-register
           path: build/elemental-register
+          overwrite: true
       - name: Store support binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elemental-support
           path: build/elemental-support
+          overwrite: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v2

--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: cosign-installer

--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: cosign-installer

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,7 @@ jobs:
       chart_name: ${{ steps.chart.outputs.chart_name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Wait for OBS crds chart
@@ -81,10 +81,11 @@ jobs:
           CHART=$(basename $FILE)
           echo "chart_name=$CHART" >> $GITHUB_OUTPUT
       - name: Upload chart
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: chart
           path: build/*.tgz
+          overwrite: true
 
   e2e-tests:
     strategy:
@@ -103,17 +104,17 @@ jobs:
       CERT_MANAGER_VERSION: v1.13.1
       SYSTEM_UPGRADE_CONTROLLER_VERSION: v0.13.1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download chart
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: chart
           path: build
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -130,8 +131,9 @@ jobs:
         run: make e2e-tests
       - name: Archive artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ci-artifacts
           path: _artifacts
           if-no-files-found: ignore
+          overwrite: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Analysis

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Log inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,12 +11,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,12 +8,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod


### PR DESCRIPTION
Use the newer versions of:

* actions/cache             -> v4
* actions/checkout          -> v4
* actions/setup-go 	    -> v5
* actions/download-artifact -> v4
* actions/upload-artifact   -> v4
