### PR TITLE
Use go.mod ginkgo version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CONTROLLER_GEN_VER := v0.9.2
 CONTROLLER_GEN := $(ABS_TOOLS_DIR)/controller-gen-$(CONTROLLER_GEN_VER)
 CONTROLLER_GEN_PKG := sigs.k8s.io/controller-tools/cmd/controller-gen
 
-GINKGO_VER := v2.3.1
+GINKGO_VER := $(shell go list -m github.com/onsi/ginkgo/v2 | awk '{print $$2}')
 GINKGO := $(ABS_TOOLS_DIR)/ginkgo-$(GINKGO_VER)
 GINKGO_PKG := github.com/onsi/ginkgo/v2/ginkgo
 


### PR DESCRIPTION
In the Makefile we try to install a hardcoded ginkgo version.

This commit uses the ginkgo version in the go.mod file instead.

It hopefully fixes the following warning in the actions logs:

 ```
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.3.1
  Mismatched package versions found:
    2.12.1 used by e2e
```