### PR TITLE
Use newer xorriso

### DIFF
--- a/Dockerfile.seedimage
+++ b/Dockerfile.seedimage
@@ -6,10 +6,10 @@ ENV CGO_ENABLED=0
 RUN go build \
     -o /usr/bin/httpfy httpfy.go
 
-FROM registry.opensuse.org/opensuse/leap:15.5 AS base
+FROM registry.opensuse.org/opensuse/tumbleweed:latest AS base
 RUN mkdir -p /installroot/etc/products.d && \
     cp /etc/products.d/baseproduct /installroot/etc/products.d/ && \
-    zypper --gpg-auto-import-keys --installroot /installroot in -y --no-recommends xorriso curl ca-certificates ca-certificates-mozilla gptfdisk squashfs util-linux grub2 dosfstools mtools e2fsprogs
+    zypper --gpg-auto-import-keys --non-interactive --installroot /installroot in --no-recommends xorriso curl ca-certificates ca-certificates-mozilla gptfdisk squashfs grub2 dosfstools mtools e2fsprogs
 
 FROM scratch AS seedimage-builder 
 COPY --from=toolkit /usr/bin/elemental /usr/bin/elemental

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ build-docker-operator:
 build-docker-seedimage-builder:
 	DOCKER_BUILDKIT=1 docker build \
 		-f Dockerfile.seedimage \
+		${DOCKER_ARGS} \
 		-t ${REGISTRY_HEADER}${REPO_SEEDIMAGE}:${TAG_SEEDIMAGE} .
 
 .PHONY: build-docker-push-operator


### PR DESCRIPTION
Since leap does not include a compatible version of xorriso, switch back to tumbleweed.

Got errors when trying to install util-linux package on tumbleweed, but it does not seem to be needed.

Logs from seedimage builder:

```shell
$ kubectl logs -n fleet-default fire-img -f -c build
xorriso 1.5.6 : RockRidge filesystem manipulator, libburnia project.
...
```
Fixes #623 