### PR TITLE
Makefile: fix commit date for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CHART?=$(shell find $(ROOT_DIR) -type f  -name "elemental-operator-$(CHART_VERSION).tgz" -print)
 KUBE_VERSION?="v1.27.10"
 CLUSTER_NAME?="operator-e2e"
-RAWCOMMITDATE=$(shell git log -n1 --format="%at")
+COMMITDATE?=$(shell git log -n1 --format="%as")
 GO_TPM_TAG?=$(shell grep google/go-tpm-tools go.mod | awk '{print $$2}')
 E2E_CONF_FILE ?= $(ROOT_DIR)/tests/e2e/config/config.yaml
 


### PR DESCRIPTION
COMMITDATE [got lost some time ago](https://github.com/rancher/elemental-operator/commit/0edac918535b95c0e7a4035ddbeb0e38cb8ddce3).
Let's have it back and in the meanwhile drop RAWCOMMITDATE which seems no longer used anywhere.

from:
```
$make register
CGO_ENABLED=1 go build -ldflags '-w -s -X "github.com/rancher/elemental-operator/pkg/version.Version=v1.5.0-dev" -X
"github.com/rancher/elemental-operator/pkg/version.Commit=634cf69a78452716e673d412ea5f77b1085bd565" -X
"github.com/rancher/elemental-operator/pkg/version.CommitDate="' -o build/elemental-register /home/fgiudici/go/src
/github.com/rancher/elemental-operator/cmd/register

$./build/elemental-register -v
I0216 19:38:05.272391   20376 log.go:42] Register version v1.5.0-dev, commit
634cf69a78452716e673d412ea5f77b1085bd565, commit date 
```
to:
```
$ make register
CGO_ENABLED=1 go build -ldflags '-w -s -X "github.com/rancher/elemental-operator/pkg/version.Version=v1.5.0-dev" -X
"github.com/rancher/elemental-operator/pkg/version.Commit=af0b4d49af5dbcfdbe4e1497522c87b8c6f58816" -X
"github.com/rancher/elemental-operator/pkg/version.CommitDate=2024-02-16"' -o build/elemental-register
/home/fgiudici/go/src/github.com/rancher/elemental-operator/cmd/register

$ ./build/elemental-register -v
I0216 19:27:42.147081   19396 log.go:42] Register version v1.5.0-dev, commit
634cf69a78452716e673d412ea5f77b1085bd565, commit date 2024-02-16
```
