### PR TITLE
Makefile/setup-full-cluster: build seedimage-builder image too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ setup-kind:
 # and run a test that does nothing but installs everything for
 # the elemental operator (nginx, rancher, operator, etc..) as part of the BeforeSuite
 # So you end up with a clean cluster in which nothing has run
-setup-full-cluster: build-docker-operator chart setup-kind
+setup-full-cluster: build-docker-operator build-docker-seedimage-builder chart setup-kind
 	@export EXTERNAL_IP=$$(kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type == "InternalIP")].address}') && \
 	export BRIDGE_IP="172.18.0.1" && \
 	export CHART=$(CHART) && \


### PR DESCRIPTION
The seedimage-builder image is needed to install the built chart: let's add it to the setup-full-cluster target.