### PR TITLE
elemental-register: collect OS data for MachineInventories annotations

### DIFF
--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -38,6 +38,7 @@ import (
 	"github.com/rancher/elemental-operator/pkg/log"
 	"github.com/rancher/elemental-operator/pkg/plainauth"
 	"github.com/rancher/elemental-operator/pkg/tpm"
+	"github.com/rancher/elemental-operator/pkg/version"
 )
 
 type Client interface {
@@ -275,7 +276,9 @@ func sendSystemData(conn *websocket.Conn) error {
 }
 
 func sendAnnotations(conn *websocket.Conn, reg elementalv1.Registration) error {
-	data := map[string]string{}
+	data := map[string]string{
+		"reg-version": version.Version,
+	}
 
 	if reg.EmulateTPM {
 		data["auth"] = "emulated-tpm"

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -317,7 +317,7 @@ func getLocalIPAddress(conn *websocket.Conn) (string, error) {
 	tcpAddr := conn.LocalAddr().String()
 	idxPortNumStart := strings.LastIndexAny(tcpAddr, ":")
 	if idxPortNumStart < 0 {
-		return "", fmt.Errorf("Cannot understand local IP address format [%s]", tcpAddr)
+		return "", fmt.Errorf("cannot understand local IP address format [%s]", tcpAddr)
 	}
 	return tcpAddr[0:idxPortNumStart], nil
 }


### PR DESCRIPTION
While there also add one more annotation to track the elemental-register version.

Fixes https://github.com/rancher/elemental/issues/1192