### PR TITLE
charts: backport changes from Rancher Marketplace chart

### DIFF
--- a/.obs/chartfile/operator/Chart.yaml
+++ b/.obs/chartfile/operator/Chart.yaml
@@ -4,7 +4,7 @@
 #!BuildTag: rancher/elemental-operator-chart:%VERSION%-%RELEASE%
 apiVersion: v2
 name: elemental-operator
-description: Rancher Elemental Operator
+description: Elemental provides Cloud Native OS Management for Cluster Nodes.
 icon: https://raw.githubusercontent.com/rancher/elemental/main/logo/icon-elemental.svg
 version: "%VERSION%"
 appVersion: "%VERSION%"
@@ -21,3 +21,4 @@ annotations:
   catalog.cattle.io/release-name: elemental-operator
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool
+  catalog.cattle.io/upstream-version: "%VERSION"

--- a/.obs/chartfile/operator/README.md
+++ b/.obs/chartfile/operator/README.md
@@ -1,0 +1,5 @@
+# Elemental Operator Helm Chart
+
+This chart bootstraps an elemental-operator deployment on a [Rancher Manager](https://rancher.com/docs/rancher/) cluster using the [Helm](https://helm.sh) package manager.
+
+Check out the [Elemental Operator Helm Chart documentation](https://elemental.docs.rancher.com/elementaloperatorchart-reference/) in the official [Elemental guide](https://elemental.docs.rancher.com/).

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -7,15 +7,15 @@ questions:
   show_subquestion_if: true
   group: "Elemental OS Channel"
   subquestions:
-  - variable: channel.repository
-    default: rancher/elemental-channel
-    description: "Specify Elemental OS channel repository"
+  - variable: channel.image
+    default: "%%IMG_REPO%%/rancher/elemental-channel"
+    description: "Specify the Elemental OS channel: for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap for detailed instructions)"
     type: string
-    label: Elemental OS Channel Repository
+    label: Elemental OS Channel Image
     group: "Elemental OS Channel"
   - variable: channel.tag
     default: "%VERSION%"
-    description: "Specify Elemental OS channel tag"
+    description: "Specify Elemental OS channel image tag"
     type: string
     label: "Elemental OS Channel Tag"
     group: "Elemental OS Channel"

--- a/.obs/chartfile/operator/templates/channel.yaml
+++ b/.obs/chartfile/operator/templates/channel.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.channel .Values.channel.repository .Values.channel.tag }}
+{{ if and .Values.channel .Values.channel.image .Values.channel.tag }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -6,6 +6,6 @@ metadata:
   namespace: fleet-default
 spec:
   options:
-    image: {{ template "registry_url" . }}{{ .Values.channel.repository }}:{{ .Values.channel.tag }}
+    image: {{ .Values.channel.image }}:{{ .Values.channel.tag }}
   type: custom
 {{ end }}

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -10,7 +10,7 @@ seedImage:
   imagePullPolicy: IfNotPresent
 
 channel:
-  repository: "rancher/elemental-channel"
+  image: "%%IMG_REPO%%/rancher/elemental-channel"
   tag: "%VERSION%"
 
 # number of operator replicas to deploy

--- a/Makefile
+++ b/Makefile
@@ -138,13 +138,15 @@ chart:
 	mv $(ROOT_DIR)/build/operator/_helmignore $(ROOT_DIR)/build/operator/.helmignore
 	yq -i '.version = "${CHART_VERSION}"' $(ROOT_DIR)/build/operator/Chart.yaml
 	yq -i '.appVersion = "${GIT_TAG}"' $(ROOT_DIR)/build/operator/Chart.yaml
+	yq -i '.annotations."catalog.cattle.io/upstream-version" = "${GIT_TAG}"' $(ROOT_DIR)/build/operator/Chart.yaml
 	yq -i '.image.tag = "${CHART_VERSION}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.image.repository = "${REPO}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.seedImage.tag = "${TAG_SEEDIMAGE}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.seedImage.repository = "${REPO_SEEDIMAGE}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.channel.tag = "${TAG_CHANNEL}"' $(ROOT_DIR)/build/operator/values.yaml
+	yq -i '.channel.image = "${REGISTRY_URL}/${REPO_CHANNEL}"' $(ROOT_DIR)/build/operator/values.yaml
+	yq -i '.questions[0].subquestions[0].default = "${REGISTRY_URL}/${REPO_CHANNEL}"' $(ROOT_DIR)/build/operator/questions.yaml
 	yq -i '.questions[0].subquestions[1].default = "${TAG_CHANNEL}"' $(ROOT_DIR)/build/operator/questions.yaml
-	yq -i '.channel.repository = "${REPO_CHANNEL}"' $(ROOT_DIR)/build/operator/values.yaml
 	yq -i '.registryUrl = "${REGISTRY_URL}"' $(ROOT_DIR)/build/operator/values.yaml
 	helm package -d $(ROOT_DIR)/build/ $(ROOT_DIR)/build/operator
 	rm -Rf $(ROOT_DIR)/build/operator


### PR DESCRIPTION
Mainly, change the var "channel.repository" to "channel.image": "repository" var values are collected by the Rancher Marketplace for air gap support. Anyway, in the case of the Elemental Channel, the image should be re-generated in case of air gap scenario following the official Elemental docs.

Also note that now the channel.image should contain the full url, not prepended with teh registryUrl or the systemDefaultRegistry.

Fixes: #649 