### PR TITLE
Review omitempty flag on API json converter

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -63,7 +63,7 @@ type SnapshotterConfig struct {
 
 type Reset struct {
 	// +optional
-	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty" mapstructure:"enabled"`
+	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	// +optional
 	// +kubebuilder:default:=true
 	ResetPersistent bool `json:"reset-persistent,omitempty" yaml:"reset-persistent,omitempty" mapstructure:"reset-persistent"`


### PR DESCRIPTION
This commit removes some omitempty flags in CRDs defintions to make them more verbose and less confusing from the user perspective.