### PR TITLE
Enable ManagedOSImage updates

### DIFF
--- a/.obs/chartfile/operator/templates/cluster_role.yaml
+++ b/.obs/chartfile/operator/templates/cluster_role.yaml
@@ -245,6 +245,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - management.cattle.io

--- a/config/rbac/bases/role.yaml
+++ b/config/rbac/bases/role.yaml
@@ -246,6 +246,7 @@ rules:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - management.cattle.io

--- a/controllers/managedosimage_controller.go
+++ b/controllers/managedosimage_controller.go
@@ -61,7 +61,7 @@ type ManagedOSImageReconciler struct {
 // +kubebuilder:rbac:groups=elemental.cattle.io,resources=managedosimages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elemental.cattle.io,resources=managedosimages/status,verbs=get;update;patch;list
 // +kubebuilder:rbac:groups=elemental.cattle.io,resources=managedosversions,verbs=get;list;watch
-// +kubebuilder:rbac:groups="fleet.cattle.io",resources=bundles,verbs=create;get;list;watch
+// +kubebuilder:rbac:groups="fleet.cattle.io",resources=bundles,verbs=create;get;update;list;watch
 
 func (r *ManagedOSImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -130,14 +130,22 @@ func (r *ManagedOSImageReconciler) reconcile(ctx context.Context, managedOSImage
 		return ctrl.Result{}, fmt.Errorf("failed to create fleet bundle resources: %w", err)
 	}
 
-	if err := r.createFleetBundle(ctx, managedOSImage, bundleResources); err != nil {
-		meta.SetStatusCondition(&managedOSImage.Status.Conditions, metav1.Condition{
-			Type:    elementalv1.FleetBundleCreation,
-			Reason:  elementalv1.FleetBundleCreateFailureReason,
-			Status:  metav1.ConditionFalse,
-			Message: err.Error(),
-		})
-		return ctrl.Result{}, fmt.Errorf("failed to create fleet bundle: %w", err)
+	// Create a new Fleet bundle if we didn't do it before. Otherwise update it.
+	if meta.IsStatusConditionTrue(managedOSImage.Status.Conditions, elementalv1.FleetBundleCreation) {
+		logger.Info("Fleet bundle already exists")
+		if err := r.updateFleetBundle(ctx, managedOSImage, bundleResources); err != nil {
+			return ctrl.Result{}, fmt.Errorf("updating Bundle from ManagedOSImage: %w", err)
+		}
+	} else {
+		if err := r.createFleetBundle(ctx, managedOSImage, bundleResources); err != nil {
+			meta.SetStatusCondition(&managedOSImage.Status.Conditions, metav1.Condition{
+				Type:    elementalv1.FleetBundleCreation,
+				Reason:  elementalv1.FleetBundleCreateFailureReason,
+				Status:  metav1.ConditionFalse,
+				Message: err.Error(),
+			})
+			return ctrl.Result{}, fmt.Errorf("creating Bundle from ManagedOSImage: %w", err)
+		}
 	}
 
 	if err := r.updateManagedOSImageStatus(ctx, managedOSImage); err != nil {
@@ -148,13 +156,6 @@ func (r *ManagedOSImageReconciler) reconcile(ctx context.Context, managedOSImage
 }
 
 func (r *ManagedOSImageReconciler) newFleetBundleResources(ctx context.Context, managedOSImage *elementalv1.ManagedOSImage) ([]fleetv1.BundleResource, error) {
-	logger := ctrl.LoggerFrom(ctx)
-
-	if meta.IsStatusConditionTrue(managedOSImage.Status.Conditions, elementalv1.FleetBundleCreation) {
-		logger.Info("Fleet bundle already exists, skipping bundle resource creation")
-		return nil, nil
-	}
-
 	cloudConfig, err := getCloudConfig(managedOSImage)
 	if err != nil {
 		return nil, err
@@ -327,33 +328,10 @@ func (r *ManagedOSImageReconciler) newFleetBundleResources(ctx context.Context, 
 
 func (r *ManagedOSImageReconciler) createFleetBundle(ctx context.Context, managedOSImage *elementalv1.ManagedOSImage, bundleResources []fleetv1.BundleResource) error {
 	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("Creating new fleet bundle")
 
-	if meta.IsStatusConditionTrue(managedOSImage.Status.Conditions, elementalv1.FleetBundleCreation) {
-		logger.Info("Fleet bundle already exists, skipping bundle resource creation")
-		return nil
-	}
-
-	bundle := &fleetv1.Bundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.SafeConcatName("mos", managedOSImage.Name),
-			Namespace: managedOSImage.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: elementalv1.GroupVersion.String(),
-					Kind:       "ManagedOSImage",
-					Name:       managedOSImage.Name,
-					UID:        managedOSImage.UID,
-					Controller: pointer.Bool(true),
-				},
-			},
-		},
-		Spec: fleetv1.BundleSpec{
-			Resources:               bundleResources,
-			BundleDeploymentOptions: fleetv1.BundleDeploymentOptions{},
-			RolloutStrategy:         managedOSImage.Spec.ClusterRolloutStrategy,
-			Targets:                 convertBundleTargets(managedOSImage.Spec.Targets),
-		},
-	}
+	bundle := &fleetv1.Bundle{}
+	r.mapImageToBundle(*managedOSImage, bundleResources, bundle)
 
 	if managedOSImage.Namespace == "fleet-local" {
 		bundle.Spec.Targets = []fleetv1.BundleTarget{{ClusterName: "local"}}
@@ -370,6 +348,62 @@ func (r *ManagedOSImageReconciler) createFleetBundle(ctx context.Context, manage
 	})
 
 	return nil
+}
+
+func (r *ManagedOSImageReconciler) updateFleetBundle(ctx context.Context, managedOSImage *elementalv1.ManagedOSImage, bundleResources []fleetv1.BundleResource) error {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("Updating existing bundle")
+
+	bundleName := r.formatBundleName(*managedOSImage)
+	bundleNamespace := managedOSImage.Namespace
+
+	bundle := &fleetv1.Bundle{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: bundleNamespace,
+		Name:      bundleName,
+	}, bundle); err != nil {
+		logger.Error(err, "Could not get expected Bundle")
+		return fmt.Errorf("getting bundle '%s/%s': %w", bundleNamespace, bundleName, err)
+	}
+	r.mapImageToBundle(*managedOSImage, bundleResources, bundle)
+
+	if managedOSImage.Namespace == "fleet-local" {
+		bundle.Spec.Targets = []fleetv1.BundleTarget{{ClusterName: "local"}}
+	}
+
+	if err := r.Update(ctx, bundle); err != nil {
+		logger.Error(err, "Could not update Bundle")
+		return fmt.Errorf("updating bundle: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ManagedOSImageReconciler) formatBundleName(managedOSImage elementalv1.ManagedOSImage) string {
+	return name.SafeConcatName("mos", managedOSImage.Name)
+}
+
+func (r *ManagedOSImageReconciler) mapImageToBundle(managedOSImage elementalv1.ManagedOSImage, bundleResources []fleetv1.BundleResource, bundle *fleetv1.Bundle) {
+	bundle.ObjectMeta.Name = r.formatBundleName(managedOSImage)
+	bundle.ObjectMeta.Namespace = managedOSImage.Namespace
+	bundle.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: elementalv1.GroupVersion.String(),
+			Kind:       "ManagedOSImage",
+			Name:       managedOSImage.Name,
+			UID:        managedOSImage.UID,
+			Controller: pointer.Bool(true),
+		},
+	}
+
+	bundle.Spec.Resources = bundleResources
+	bundle.Spec.RolloutStrategy = managedOSImage.Spec.ClusterRolloutStrategy
+
+	if managedOSImage.Namespace == "fleet-local" {
+		bundle.Spec.Targets = []fleetv1.BundleTarget{{ClusterName: "local"}}
+	} else {
+		bundle.Spec.Targets = convertBundleTargets(managedOSImage.Spec.Targets)
+	}
 }
 
 func (r *ManagedOSImageReconciler) updateManagedOSImageStatus(ctx context.Context, managedOSImage *elementalv1.ManagedOSImage) error {

--- a/controllers/managedosimage_controller.go
+++ b/controllers/managedosimage_controller.go
@@ -49,6 +49,7 @@ import (
 
 const (
 	rancherSystemNamespace = "cattle-system"
+	fleetLocalNamespace    = "fleet-local"
 )
 
 // ManagedOSImageReconciler reconciles a ManagedOSImage object.
@@ -121,7 +122,7 @@ func (r *ManagedOSImageReconciler) reconcile(ctx context.Context, managedOSImage
 
 	logger.Info("Reconciling managed OS image object")
 
-	if managedOSImage.Namespace == "fleet-local" && len(managedOSImage.Spec.Targets) > 0 { // TODO: this should be a part of validation webhook
+	if managedOSImage.Namespace == fleetLocalNamespace && len(managedOSImage.Spec.Targets) > 0 { // TODO: this should be a part of validation webhook
 		return ctrl.Result{}, errors.New("spec.targets should be empty if in the fleet-local namespace")
 	}
 
@@ -333,7 +334,7 @@ func (r *ManagedOSImageReconciler) createFleetBundle(ctx context.Context, manage
 	bundle := &fleetv1.Bundle{}
 	r.mapImageToBundle(*managedOSImage, bundleResources, bundle)
 
-	if managedOSImage.Namespace == "fleet-local" {
+	if managedOSImage.Namespace == fleetLocalNamespace {
 		bundle.Spec.Targets = []fleetv1.BundleTarget{{ClusterName: "local"}}
 	}
 
@@ -367,7 +368,7 @@ func (r *ManagedOSImageReconciler) updateFleetBundle(ctx context.Context, manage
 	}
 	r.mapImageToBundle(*managedOSImage, bundleResources, bundle)
 
-	if managedOSImage.Namespace == "fleet-local" {
+	if managedOSImage.Namespace == fleetLocalNamespace {
 		bundle.Spec.Targets = []fleetv1.BundleTarget{{ClusterName: "local"}}
 	}
 
@@ -399,7 +400,7 @@ func (r *ManagedOSImageReconciler) mapImageToBundle(managedOSImage elementalv1.M
 	bundle.Spec.Resources = bundleResources
 	bundle.Spec.RolloutStrategy = managedOSImage.Spec.ClusterRolloutStrategy
 
-	if managedOSImage.Namespace == "fleet-local" {
+	if managedOSImage.Namespace == fleetLocalNamespace {
 		bundle.Spec.Targets = []fleetv1.BundleTarget{{ClusterName: "local"}}
 	} else {
 		bundle.Spec.Targets = convertBundleTargets(managedOSImage.Spec.Targets)

--- a/controllers/managedosimage_controller_test.go
+++ b/controllers/managedosimage_controller_test.go
@@ -227,7 +227,7 @@ var _ = Describe("createFleetBundle", func() {
 	})
 
 	It("should change target when namespace is fleet-local", func() {
-		managedOSImage.Namespace = "fleet-local"
+		managedOSImage.Namespace = fleetLocalNamespace
 		err := r.createFleetBundle(ctx, managedOSImage, []fleetv1.BundleResource{
 			{
 				Name: "test",

--- a/controllers/managedosimage_controller_test.go
+++ b/controllers/managedosimage_controller_test.go
@@ -160,18 +160,6 @@ var _ = Describe("newFleetBundleResources", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(bundleResources).To(BeNil())
 	})
-
-	It("return early if fleet bundle already exists", func() {
-		meta.SetStatusCondition(&managedOSImage.Status.Conditions, metav1.Condition{
-			Type:   elementalv1.FleetBundleCreation,
-			Reason: elementalv1.FleetBundleCreateSuccessReason,
-			Status: metav1.ConditionTrue,
-		})
-
-		bundleResources, err := r.newFleetBundleResources(ctx, managedOSImage)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(bundleResources).To(BeNil())
-	})
 })
 
 var _ = Describe("createFleetBundle", func() {
@@ -248,7 +236,7 @@ var _ = Describe("createFleetBundle", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cl.Get(ctx, client.ObjectKey{
-			Name:      name.SafeConcatName("mos", managedOSImage.Name),
+			Name:      r.formatBundleName(*managedOSImage),
 			Namespace: managedOSImage.Namespace,
 		}, bundle)).To(Succeed())
 
@@ -260,15 +248,22 @@ var _ = Describe("createFleetBundle", func() {
 		Expect(bundle.Spec.Targets[0].ClusterName).To(Equal("local"))
 	})
 
-	It("return early if fleet bundle already exists", func() {
+	It("update fleet bundle if already exists", func() {
+		Expect(r.createFleetBundle(ctx, managedOSImage, []fleetv1.BundleResource{})).Should(Succeed())
 		meta.SetStatusCondition(&managedOSImage.Status.Conditions, metav1.Condition{
 			Type:   elementalv1.FleetBundleCreation,
 			Reason: elementalv1.FleetBundleCreateSuccessReason,
 			Status: metav1.ConditionTrue,
 		})
 
-		err := r.createFleetBundle(ctx, managedOSImage, []fleetv1.BundleResource{})
-		Expect(err).ToNot(HaveOccurred())
+		wantResource := []fleetv1.BundleResource{{Name: "test", Content: "test-content"}}
+		Expect(r.updateFleetBundle(ctx, managedOSImage, wantResource)).Should(Succeed())
+
+		Expect(cl.Get(ctx, client.ObjectKey{
+			Name:      r.formatBundleName(*managedOSImage),
+			Namespace: managedOSImage.Namespace,
+		}, bundle)).To(Succeed())
+		Expect(bundle.Spec.Resources).To(Equal(wantResource))
 	})
 })
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -64,7 +64,7 @@ var _ = BeforeSuite(func() {
 
 	Expect(cl.Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "fleet-local",
+			Name: fleetLocalNamespace,
 		},
 	})).To(Succeed())
 })


### PR DESCRIPTION
Part of rancher/elemental#1268

This PR makes the ManagedOSImage an editable resource. 
It is intended that in order to bump the OS version on all targeted clusters for example, it should be enough to update the `ManagedOSImage.Spec.osImage` field. The linked bundle will be updated if there are any changes and the `system-upgrade-controller` running on the Elemental node should execute it again.