### PR TITLE
Drain nodes by default on upgrade

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -1380,6 +1380,7 @@ spec:
                   skipWaitForDeleteTimeout: 60
                 description: DrainSpec encapsulates `kubectl drain` parameters minus
                   node/pod selectors.
+                nullable: true
                 properties:
                   deleteLocalData:
                     type: boolean
@@ -1785,6 +1786,8 @@ spec:
                   image:
                     type: string
                 type: object
+            required:
+            - drain
             type: object
           status:
             properties:

--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -1375,6 +1375,9 @@ spec:
               cordon:
                 type: boolean
               drain:
+                default:
+                  force: true
+                  skipWaitForDeleteTimeout: 60
                 description: DrainSpec encapsulates `kubectl drain` parameters minus
                   node/pod selectors.
                 properties:

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ build-docker-push-seedimage-builder: build-docker-seedimage-builder
 	docker push ${REGISTRY_HEADER}${REPO_SEEDIMAGE}:${TAG_SEEDIMAGE}
 
 .PHONY: chart
-chart:
+chart: build-manifests
 	mkdir -p  $(ROOT_DIR)/build
 	cp -rf $(ROOT_DIR)/.obs/chartfile/crds $(ROOT_DIR)/build/crds
 	mv $(ROOT_DIR)/build/crds/_helmignore $(ROOT_DIR)/build/crds/.helmignore

--- a/api/v1beta1/managedosimage_types.go
+++ b/api/v1beta1/managedosimage_types.go
@@ -49,6 +49,7 @@ type ManagedOSImageSpec struct {
 	// +optional
 	Cordon *bool `json:"cordon,omitempty"`
 	// +optional
+	// +kubebuilder:default:={"force":true,"skipWaitForDeleteTimeout":60}
 	Drain *upgradev1.DrainSpec `json:"drain,omitempty"`
 	// +optional
 	UpgradeContainer *upgradev1.ContainerSpec `json:"upgradeContainer,omitempty"`

--- a/api/v1beta1/managedosimage_types.go
+++ b/api/v1beta1/managedosimage_types.go
@@ -48,9 +48,9 @@ type ManagedOSImageSpec struct {
 	Prepare *upgradev1.ContainerSpec `json:"prepare,omitempty"`
 	// +optional
 	Cordon *bool `json:"cordon,omitempty"`
-	// +optional
+	// +nullable
 	// +kubebuilder:default:={"force":true,"skipWaitForDeleteTimeout":60}
-	Drain *upgradev1.DrainSpec `json:"drain,omitempty"`
+	Drain *upgradev1.DrainSpec `json:"drain"`
 	// +optional
 	UpgradeContainer *upgradev1.ContainerSpec `json:"upgradeContainer,omitempty"`
 	// +optional

--- a/config/crd/bases/elemental.cattle.io_managedosimages.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosimages.yaml
@@ -393,6 +393,7 @@ spec:
                   skipWaitForDeleteTimeout: 60
                 description: DrainSpec encapsulates `kubectl drain` parameters minus
                   node/pod selectors.
+                nullable: true
                 properties:
                   deleteLocalData:
                     type: boolean
@@ -798,6 +799,8 @@ spec:
                   image:
                     type: string
                 type: object
+            required:
+            - drain
             type: object
           status:
             properties:

--- a/config/crd/bases/elemental.cattle.io_managedosimages.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosimages.yaml
@@ -388,6 +388,9 @@ spec:
               cordon:
                 type: boolean
               drain:
+                default:
+                  force: true
+                  skipWaitForDeleteTimeout: 60
                 description: DrainSpec encapsulates `kubectl drain` parameters minus
                   node/pod selectors.
                 properties:

--- a/controllers/managedosimage_controller.go
+++ b/controllers/managedosimage_controller.go
@@ -263,6 +263,16 @@ func (r *ManagedOSImageReconciler) newFleetBundleResources(ctx context.Context, 
 					APIGroups: []string{""},
 					Resources: []string{"pods"},
 				},
+				{
+					Verbs:     []string{"get"},
+					APIGroups: []string{"apps"},
+					Resources: []string{"daemonsets"},
+				},
+				{
+					Verbs:     []string{"create"},
+					APIGroups: []string{""},
+					Resources: []string{"pods/eviction"},
+				},
 			},
 		},
 		&rbacv1.ClusterRoleBinding{

--- a/controllers/managedosimage_controller_test.go
+++ b/controllers/managedosimage_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("newFleetBundleResources", func() {
 
 		Expect(bundleResources).To(HaveLen(5))
 
-		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-87f8d805a5c0.yaml"))
+		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-28ceb391618a.yaml"))
 		Expect(bundleResources[1].Name).To(Equal("ClusterRoleBinding--os-upgrader-test-name-cc7ce4275b54.yaml"))
 		Expect(bundleResources[2].Name).To(Equal("ServiceAccount-cattle-system-os-upgrader-test-name-08929531f5c0.yaml"))
 		Expect(bundleResources[3].Name).To(Equal("Secret-cattle-system-os-upgrader-test-name-52e9d8e041f4.yaml"))

--- a/tests/catalog/managedosimage.go
+++ b/tests/catalog/managedosimage.go
@@ -38,6 +38,7 @@ func NewManagedOSImage(namespace string, name string, targets []elementalv1.Bund
 			OSImage:              mosImage,
 			ManagedOSVersionName: mosVersionName,
 			Cordon:               &cordon,
+			Drain:                nil,
 			Targets:              targets,
 		},
 	}

--- a/tests/e2e/upgrades_test.go
+++ b/tests/e2e/upgrades_test.go
@@ -112,9 +112,8 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 		osImage := "update-osversion"
 		osVersion := "osversion"
 		AfterEach(func() {
-			k.Delete("managedosversion", "-n", fleetNamespace, "--all")
-			k.Delete("managedosimage", "-n", fleetNamespace, "--all")
-			k.Delete("managedosversionchannel", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("managedosimage", "-n", fleetNamespace, osImage)
+			k.Delete("managedosversion", "-n", fleetNamespace, osVersion)
 
 			// Plans do not successfully apply, so nodes stays in cordoned state.
 			// uncordon them so tests will keep running
@@ -125,6 +124,7 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 			k.Delete("jobs", "--all", "--wait", "-n", fleetNamespace)
 			k.Delete("plans", "--all", "--wait", "-n", fleetNamespace)
 			k.Delete("bundles", "--all", "--wait", "-n", fleetNamespace)
+			k.Delete("managedosversionchannel", "--all", "--wait", "-n", fleetNamespace)
 
 			// delete dangling upgrade pods
 			EventuallyWithOffset(1, func() []string {

--- a/tests/e2e/upgrades_test.go
+++ b/tests/e2e/upgrades_test.go
@@ -112,8 +112,9 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 		osImage := "update-osversion"
 		osVersion := "osversion"
 		AfterEach(func() {
-			k.Delete("managedosimage", "-n", fleetNamespace, osImage)
-			k.Delete("managedosversion", "-n", fleetNamespace, osVersion)
+			k.Delete("managedosversion", "-n", fleetNamespace, "--all")
+			k.Delete("managedosimage", "-n", fleetNamespace, "--all")
+			k.Delete("managedosversionchannel", "--all", "--wait", "-n", fleetNamespace)
 
 			// Plans do not successfully apply, so nodes stays in cordoned state.
 			// uncordon them so tests will keep running
@@ -124,7 +125,6 @@ var _ = Describe("ManagedOSImage Upgrade e2e tests", func() {
 			k.Delete("jobs", "--all", "--wait", "-n", fleetNamespace)
 			k.Delete("plans", "--all", "--wait", "-n", fleetNamespace)
 			k.Delete("bundles", "--all", "--wait", "-n", fleetNamespace)
-			k.Delete("managedosversionchannel", "--all", "--wait", "-n", fleetNamespace)
 
 			// delete dangling upgrade pods
 			EventuallyWithOffset(1, func() []string {


### PR DESCRIPTION
This PR enables drain options by default on `ManagedOSImages`
With defaults:

```yaml
  drain:
    force: true
    skipWaitForDeleteTimeout: 60
```