### PR TITLE
Align DrainSpec to system-upgrade-controller defaults

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -1376,7 +1376,9 @@ spec:
                 type: boolean
               drain:
                 default:
+                  deleteLocalData: true
                   force: true
+                  ignoreDaemonSets: true
                   skipWaitForDeleteTimeout: 60
                 description: DrainSpec encapsulates `kubectl drain` parameters minus
                   node/pod selectors.

--- a/api/v1beta1/managedosimage_types.go
+++ b/api/v1beta1/managedosimage_types.go
@@ -49,7 +49,7 @@ type ManagedOSImageSpec struct {
 	// +optional
 	Cordon *bool `json:"cordon,omitempty"`
 	// +nullable
-	// +kubebuilder:default:={"force":true,"skipWaitForDeleteTimeout":60}
+	// +kubebuilder:default:={"force":true,"skipWaitForDeleteTimeout":60,"ignoreDaemonSets":true,"deleteLocalData":true}
 	Drain *upgradev1.DrainSpec `json:"drain"`
 	// +optional
 	UpgradeContainer *upgradev1.ContainerSpec `json:"upgradeContainer,omitempty"`

--- a/config/crd/bases/elemental.cattle.io_managedosimages.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosimages.yaml
@@ -389,7 +389,9 @@ spec:
                 type: boolean
               drain:
                 default:
+                  deleteLocalData: true
                   force: true
+                  ignoreDaemonSets: true
                   skipWaitForDeleteTimeout: 60
                 description: DrainSpec encapsulates `kubectl drain` parameters minus
                   node/pod selectors.


### PR DESCRIPTION
Align to this: https://github.com/rancher/system-upgrade-controller/blob/master/pkg/upgrade/job/job.go#L316