### PR TITLE
Use /run/elemental and elemental- services

### DIFF
--- a/cmd/support/main.go
+++ b/cmd/support/main.go
@@ -67,7 +67,17 @@ func getServices() []string {
 		"cos-setup-reconcile",
 		"cos-setup-rootfs",
 		"cos-immutable-rootfs",
+		"elemental-setup-boot",
+		"elemental-setup-fs",
+		"elemental-setup-initramfs",
+		"elemental-setup-network",
+		"elemental-setup-reconcile",
+		"elemental-setup-rootfs",
+		"elemental-immutable-rootfs",
 		"elemental",
+		"elemental-register",
+		"elemental-register-install",
+		"elemental-register-reset",
 		"NetworkManager",
 	}
 }

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -274,7 +274,7 @@ func (r *MachineInventoryReconciler) newResetPlan(ctx context.Context) (string, 
 		Stages: map[string][]schema.Stage{
 			"network.after": {
 				schema.Stage{
-					If:   "[ -f /run/cos/recovery_mode ]",
+					If:   "[ -f /run/cos/recovery_mode ] || [ -f /run/elemental/recovery_mode ]",
 					Name: "Runs elemental reset",
 					Commands: []string{
 						"systemctl start elemental-register-reset",

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -910,7 +910,7 @@ func serializeResetRegistrationYaml(config *elementalv1.Config) ([]byte, error) 
 		Stages: map[string][]schema.Stage{
 			"initramfs": {
 				schema.Stage{
-					If:   `[ -f "/run/cos/recovery_mode" ]`,
+					If:   `[ -f "/run/cos/recovery_mode" ] || [ -f "/run/elemental/recovery_mode" ]`,
 					Name: "Save registration config",
 					Directories: []schema.Directory{
 						{


### PR DESCRIPTION
Use /run/elemental to check on recovery state and add 'elemental-*` services to support log collection.