### PR TITLE
[Airgap] add basic tests for the airgap script

### DIFF
--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -1,0 +1,25 @@
+name: Airgap script test
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+concurrency:
+  group: airgap-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install docker
+      uses: docker-practice/actions-setup-docker@master
+      timeout-minutes: 12
+    - name: Install Helm
+      run: sudo snap install helm --classic
+    - name: Install yq
+      uses: mikefarah/yq@v4.28.2
+    - name: Install jq
+      run: sudo apt install jq -y
+    - name: Run test
+      run: make airgap-script-test

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,10 @@ validate:
 unit-tests: $(SETUP_ENVTEST) $(GINKGO)
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(ABS_TOOLS_DIR) -p path)" $(GINKGO) -v -r --trace --race --covermode=atomic --coverprofile=coverage.out --coverpkg=github.com/rancher/elemental-operator/... ./pkg/... ./controllers/... ./cmd/...
 
+.PHONY: airgap-script-test
+airgap-script-test:
+	scripts/elemental-airgap-test.sh
+
 e2e-tests: $(GINKGO)
 	kubectl cluster-info --context kind-$(CLUSTER_NAME)
 	kubectl label nodes --all --overwrite ingress-ready=true

--- a/scripts/elemental-airgap-test.sh
+++ b/scripts/elemental-airgap-test.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+get_docker_image_version() {
+  local store_var="$1"
+  local image_name="$2"
+
+  [ -z "$image_name" -o -z "$store_var" ] && return 1
+
+  outarray=($(docker images | grep $image_name))
+  [ $? -ne 0 ] && return 1
+
+  eval $store_var=\${outarray[1]}
+  return 0
+}
+
+# get_json_val "VARNAME" "JSONDATA" "JSONFIELD"
+# receives a json data snippet as JSONDATA and the json field to retrieve as JSONFIELD.
+# puts the value extracted in a variable called as VARNAME.
+get_json_val() {
+    local local_var="$1"
+    local jsondata="$2"
+    local local_val="$3"
+
+    eval $local_var=$(echo $jsondata | jq $local_val)
+}
+
+check_channel_json() {
+  local channel_file="$1"
+
+  for i in $(seq 0 20); do
+    local item item_type item_image item_name item_url_field
+    item=$(jq .[$i] $channel_file)
+    [ "$item" = "null" ] && break
+
+    get_json_val item_name "$item" ".metadata.name"
+    get_json_val item_type "$item" ".spec.type"
+    get_json_val item_display "$item" ".spec.metadata.displayName"
+
+    case $item_type in
+      container)
+      item_url_field=".spec.metadata.upgradeImage"
+      ;;
+      iso)
+      item_url_field=".spec.metadata.uri"
+      ;;
+      *)
+      echo "ERR: unexpected entry type in channel: '$item_type'"
+      return 1
+      ;;
+    esac
+    get_json_val item_image "$item" "$item_url_field"
+
+    echo " found image '$item_image'"
+    orig_image=${item_image#$LOCAL_REGISTRY/}
+    if [ "$orig_image" = "$item_image" ]; then
+      echo "ERR: OS images in the created channel image are not prepended with the private registry URL"
+      return 1 
+    fi
+
+    if ! docker manifest inspect $orig_image > /dev/null; then
+      echo "ERR: source OS image '$orig_image' cannot be found"
+      return 1
+    fi
+  done
+  
+  return 0
+SKIP_ARCHIVE_CREATION
+}
+
+
+LOCAL_REGISTRY="private.reg:5000"
+AIRGAPSCRIPT_PATH="scripts/elemental-airgap.sh"
+
+echo "AIRGAP ELEMENTAL SCRIPT TESTING"
+for ELEMENTAL_RELEASE in stable staging dev; do
+
+  echo "testing ELEMENTAL RELEASE '$ELEMENTAL_RELEASE'"
+
+  uuid=$(cat /proc/sys/kernel/random/uuid)
+  CHANNEL_IMAGE_NAME="rancher/elemental-channel-$uuid"
+  export CHANNEL_IMAGE_NAME
+
+
+  cmd="${AIRGAPSCRIPT_PATH} -d -sa -r ${LOCAL_REGISTRY} ${ELEMENTAL_RELEASE}"
+  echo "RUN: $cmd"
+  if ! $cmd; then
+    echo "['$ELEMENTAL_RELEASE'] FAILED: airgap script returned error"
+    exit 1
+  fi
+  echo "['$ELEMENTAL_RELEASE'] PASSED: archive creation"
+
+  version=""
+  if ! get_docker_image_version version "$CHANNEL_IMAGE_NAME"; then
+    echo "['$ELEMENTAL_RELEASE'] FAILED: cannot retrieve local $CHANNEL_IMAGE_NAME"
+    exit 1
+  fi
+
+  if ! docker run --entrypoint busybox ${CHANNEL_IMAGE_NAME}:$version cat channel.json > "${uuid}.json"; then
+    echo "['$ELEMENTAL_RELEASE'] FAILED: cannot extract the list of OS URLs from the local channel image: ${CHANNEL_IMAGE_NAME}:$version"
+    exit 1
+  fi
+
+  if ! check_channel_json "${uuid}.json"; then
+    echo "['$ELEMENTAL_RELEASE'] FAILED: generated OS channel inspection"
+    exit 1
+  fi
+  echo "['$ELEMENTAL_RELEASE'] PASSED: inspected generated OS channel"
+
+  rm ${uuid}.json
+done
+
+echo "ALL TESTS PASSED!"
+exit 0

--- a/scripts/elemental-airgap.sh
+++ b/scripts/elemental-airgap.sh
@@ -203,7 +203,7 @@ get_chart_val() {
     eval $local_var=$(helm show values $CHART_NAME_OPERATOR | eval yq eval '.${local_val}' | sed s/\"//g 2>&1)
     if eval $local_condition; then
         if [[ "$local_fail" == "false" ]]; then
-            log_debug "cannot find \$local_val in $CHART_NAME_OPERATOR"
+            log_debug "cannot find $local_val in $CHART_NAME_OPERATOR"
             eval $local_var=""
             return 0
         fi


### PR DESCRIPTION
Will build a channel OS image for a private registry using the stable, staging and dev charts links.
Will check the OS URLs generated inside the new channel image for the private registry.

Add the test to a new github workflow to be ran on each new PR.

Fixes #666 