### PR TITLE
Allow dots in the hostnames / MachineInventory names

### DIFF
--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -253,12 +253,6 @@ func replaceStringData(data map[string]interface{}, name string) (string, error)
 	}
 
 	resultStr := sanitizeString(result.String())
-	if !start.MatchString(resultStr) {
-		resultStr = "m" + resultStr
-	}
-	if len(resultStr) > 58 {
-		resultStr = resultStr[:58]
-	}
 	return resultStr, nil
 }
 
@@ -535,6 +529,12 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 func sanitizeString(s string) string {
 	s1 := sanitize.ReplaceAllString(s, "-")
 	s2 := doubleDash.ReplaceAllString(s1, "-")
+	if !start.MatchString(s2) {
+		s2 = "m" + s2
+	}
+	if len(s2) > 58 {
+		s2 = s2[:58]
+	}
 	return s2
 }
 

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -252,8 +252,7 @@ func replaceStringData(data map[string]interface{}, name string) (string, error)
 		str = str[j+i+1:]
 	}
 
-	resultStr := sanitizeString(result.String())
-	return resultStr, nil
+	return result.String(), nil
 }
 
 func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elementalv1.MachineInventory, registration *elementalv1.MachineRegistration) error {
@@ -436,6 +435,7 @@ func updateInventoryFromSMBIOSData(data []byte, mInventory *elementalv1.MachineI
 	// to set the machine hostname. Also set it to lowercase
 	name, err := replaceStringData(smbiosData, mInventory.Name)
 	if err == nil {
+		name = sanitizeString(name)
 		mInventory.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
 	} else {
 		if errors.Is(err, errValueNotFound) {
@@ -461,6 +461,7 @@ func updateInventoryFromSMBIOSData(data []byte, mInventory *elementalv1.MachineI
 			log.Errorf("Failed parsing smbios data: %v", err.Error())
 			return err
 		}
+		parsedData = sanitizeString(parsedData)
 
 		log.Debugf("Parsed %s into %s with smbios data, setting it to label %s", v, parsedData, k)
 		mInventory.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(parsedData, "-"), "-")
@@ -493,6 +494,7 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 			return err
 		}
 	}
+	name = sanitizeString(name)
 
 	inv.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
 
@@ -514,6 +516,7 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 			log.Errorf("Failed parsing system data: %v", err.Error())
 			return err
 		}
+		parsedData = sanitizeString(parsedData)
 
 		log.Debugf("Parsed %s into %s with system data, setting it to label %s", v, parsedData, k)
 		inv.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(parsedData, "-"), "-")

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -193,6 +193,7 @@ func TestBuildName(t *testing.T) {
 		t.Run(testCase.Format, func(t *testing.T) {
 			str, err := replaceStringData(data, testCase.Format)
 			if testCase.Error == "" {
+				str = sanitizeString(str)
 				assert.NilError(t, err)
 				assert.Equal(t, testCase.Output, str, "'%s' not equal to '%s'", testCase.Output, str)
 			} else {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -159,6 +159,7 @@ func initInventory(inventory *elementalv1.MachineInventory, registration *elemen
 	inventory.Labels = map[string]string{}
 	for k, v := range registration.Spec.MachineInventoryLabels {
 		value, _ := replaceStringData(map[string]interface{}{}, v)
+		value = sanitizeString(value)
 		inventory.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(value, "-"), "-")
 	}
 


### PR DESCRIPTION
The MachineRegistration 'machineName', when set is used as the blueprint for generating the MachineInventory name.
The MachineInventory name is set on the associated host as the hostname during k3s/RKE2 provisioning.

With the recent introduction of the hostname data label, we allow the users to use the pre-registration hostname of the host as the machine inventory name (which will be later enforced as the static hostname).
This could be useful to preserve an hostname assigned by a DHCP server.
Hostnames assigned from a DHCP server usually ends with the network domain name of the organization.

Current sanitization of the "data-labels" (hw-labels and SMBIOS labels) do not allow dots, which are replaced with hypens.
Since the Registration 'machineName' field, and so the MachineInventory name, are not treated differently than the other data-labels, the DHCP assigned hostnames will be changed.
This not only will impact the MachineInventory name, but will also change the machine hostnames on K8s provisioning.

Since this is a nasty bug (will affect the hostnames and the kubernetes node names of the deployed clusters) it should be backported to 1.4.x ASAP. For this reason, _**the changes in this PR are kept to the minimum**_: the first two commits just move code around and decople data-labels substitution from sanitization.
The fix and the functional change is in the last commit: we just add the dot in the allowed character set for the MachineInventory name only.

Once this is merged, we may want to rework the sanitization code for the labels, annotations and the hostname and maybe embrace more relaxed constraints.

Fixes #677 