### PR TITLE
Add extension to seedimage url

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -447,8 +447,14 @@ func (r *SeedImageReconciler) updateStatusFromPod(ctx context.Context, seedImg *
 			})
 			return errMsg
 		}
+
+		// Use the registration name or else default to "elemental" for the image file name
+		imageName := "elemental"
+		if seedImg.Spec.MachineRegistrationRef != nil && len(seedImg.Spec.MachineRegistrationRef.Name) > 0 {
+			imageName = seedImg.Spec.MachineRegistrationRef.Name
+		}
 		seedImg.Status.DownloadToken = token
-		seedImg.Status.DownloadURL = fmt.Sprintf("https://%s/elemental/seedimage/%s", rancherURL, token)
+		seedImg.Status.DownloadURL = fmt.Sprintf("https://%s/elemental/seedimage/%s/%s.%s", rancherURL, token, imageName, seedImg.Spec.Type)
 		meta.SetStatusCondition(&seedImg.Status.Conditions, metav1.Condition{
 			Type:    elementalv1.SeedImageConditionReady,
 			Status:  metav1.ConditionTrue,

--- a/pkg/server/api_seedimage.go
+++ b/pkg/server/api_seedimage.go
@@ -34,9 +34,9 @@ func (i *InventoryServer) apiSeedImage(resp http.ResponseWriter, req *http.Reque
 	var err error
 	var seedImg *elementalv1.SeedImage
 
-	// expected splittedPath = {"seedimage", {token}}
-	if len(splittedPath) != 2 {
-		err = fmt.Errorf("seedimage not found")
+	// expected splittedPath = {"seedimage", {token}, {imgName.imgType}}
+	if len(splittedPath) < 2 {
+		err = fmt.Errorf("unexpected path: %v", splittedPath)
 		http.Error(resp, err.Error(), http.StatusNotFound)
 		return err
 	}


### PR DESCRIPTION
Closes #673 

This makes the URL a bit more readable: 
```
downloadURL: https://172.18.0.2.sslip.io/elemental/seedimage/2gb2ctz4ptb8c5ww4pmnkvnmbtlbw7fbxjt98rldq6r6c67wqj8h6p/fire-nodes.iso
```

It's also backward compatible, so that querying `https://172.18.0.2.sslip.io/elemental/seedimage/2gb2ctz4ptb8c5ww4pmnkvnmbtlbw7fbxjt98rldq6r6c67wqj8h6p` is working as expected for all those SeedImages already built.