### PR TITLE
Unit tests: add some more coverage to registration and seedimage API

### DIFF
--- a/pkg/plainauth/plainauth.go
+++ b/pkg/plainauth/plainauth.go
@@ -55,7 +55,7 @@ func (a *AuthServer) Authenticate(_ *websocket.Conn, req *http.Request, regNames
 	log.Info("Authentication: PLAIN")
 	idToken := strings.TrimPrefix(header, "Bearer PLAIN")
 	if idToken == "" {
-		return nil, false, fmt.Errorf("Cannot find token ID")
+		return nil, false, fmt.Errorf("cannot find token ID")
 	}
 	hashedToken := fmt.Sprintf("%x", sha256.Sum256([]byte(idToken)))
 

--- a/pkg/plainauth/register_test.go
+++ b/pkg/plainauth/register_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plainauth
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+)
+
+func TestRegisterPlainAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Register PlainAuth")
+}
+
+var _ = Describe("is not filled", Label("plainauth"), func() {
+	It("returns true when empty", func() {
+		value := ""
+		res := isNotFilled(value)
+		Expect(res).To(BeTrue())
+	})
+	It("returns true when 'Unspecified'", func() {
+		value := "Unspecified"
+		res := isNotFilled(value)
+		Expect(res).To(BeTrue())
+	})
+	It("returns true when 'None'", func() {
+		value := "None"
+		res := isNotFilled(value)
+		Expect(res).To(BeTrue())
+	})
+	It("returns true when 'Not ...'", func() {
+		value := "Not Present"
+		res := isNotFilled(value)
+		Expect(res).To(BeTrue())
+	})
+	It("returns false when has a regular value", func() {
+		value := "Data"
+		res := isNotFilled(value)
+		Expect(res).To(BeFalse())
+	})
+})
+
+var _ = Describe("authentication client init", Label("plainauth"), func() {
+	It("returns error on unknown registration authentication", func() {
+		reg := elementalv1.Registration{
+			Auth: "unknown",
+		}
+		authCli := AuthClient{}
+		err := authCli.Init(reg)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/register/register_test.go
+++ b/pkg/register/register_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package register
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/plainauth"
+	"github.com/rancher/elemental-operator/pkg/tpm"
+)
+
+func echo(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	for {
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		err = conn.WriteMessage(msgType, data)
+		if err != nil {
+			return
+		}
+	}
+}
+
+var _ = Describe("authenticate", Label("registration", "core"), func() {
+	var server *httptest.Server
+	var conn *websocket.Conn
+	var registration elementalv1.Registration
+
+	BeforeEach(func() {
+		server = httptest.NewServer(http.HandlerFunc(echo))
+		DeferCleanup(server.Close)
+	})
+
+	Context("plain authentication data is provided", func() {
+		var auth authClient
+
+		BeforeEach(func() {
+			registration = elementalv1.Registration{
+				Auth: "mac",
+			}
+			auth = &plainauth.AuthClient{}
+			err := auth.Init(registration)
+			Expect(err).ToNot(HaveOccurred())
+
+			url := "ws" + strings.TrimPrefix(server.URL, "http")
+			conn, _, err = websocket.DefaultDialer.Dial(url, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("succedes if the remote endpoint acknowledges authentication", func() {
+			err := conn.WriteMessage(websocket.BinaryMessage, insertMessageType(MsgReady, []byte("data")))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = authenticate(conn, auth)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("fails if the remote endpoint does not acknowledge authentication", func() {
+			err := conn.WriteMessage(websocket.BinaryMessage, insertMessageType(MsgError, []byte("data")))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = authenticate(conn, auth)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("expecting '%v' but got", MsgReady)))
+		})
+	})
+})
+
+var _ = Describe("initialize websocket", Label("registration", "core"), func() {
+	var server *httptest.Server
+	var auth authClient
+
+	BeforeEach(func() {
+		server = httptest.NewServer((http.HandlerFunc(echo)))
+		DeferCleanup(server.Close)
+	})
+
+	When("authentication data is provided", func() {
+		var registration elementalv1.Registration
+
+		BeforeEach(func() {
+			registration = elementalv1.Registration{
+				EmulateTPM:      true,
+				EmulatedTPMSeed: 10,
+			}
+			auth = &tpm.AuthClient{}
+
+			err := auth.Init(registration)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("establishes a working connection with the remote endpoint", func() {
+			conn, err := initWebsocketConn(server.URL+"/token", []byte{}, auth)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = conn.WriteMessage(websocket.BinaryMessage, []byte("test"))
+			Expect(err).ToNot(HaveOccurred())
+
+			_, data, err := conn.ReadMessage()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(data)).To(Equal("test"))
+		})
+
+		Context("if registration URL is missing", func() {
+			It("returns a dialer error", func() {
+				_, err := initWebsocketConn("", []byte{}, auth)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("malformed ws or wss URL"))
+			})
+		})
+	})
+
+	When("authentication data is not provided", func() {
+
+		BeforeEach(func() {
+			auth = &plainauth.AuthClient{}
+		})
+
+		It("returns an authentication error", func() {
+			_, err := initWebsocketConn(server.URL+"/token", []byte{}, auth)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot generate authentication"))
+		})
+	})
+})
+
+var _ = Describe("authenticator", Label("registration", "core"), func() {
+	var reg elementalv1.Registration
+	var state *State
+
+	BeforeEach(func() {
+		state = &State{}
+	})
+
+	It("returns TPM authentication on auth=tpm registration", func() {
+		reg = elementalv1.Registration{
+			Auth: "tpm",
+		}
+
+		auth, err := getAuthenticator(reg, state)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(auth.GetName()).To(Equal("TPM"))
+		Expect(state.EmulatedTPM).To(BeFalse())
+	})
+
+	It("fills State with TPM emulation data from registration", func() {
+		reg = elementalv1.Registration{
+			Auth:            "tpm",
+			EmulateTPM:      true,
+			EmulatedTPMSeed: 10,
+		}
+
+		auth, err := getAuthenticator(reg, state)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(auth.GetName()).To(Equal("TPM"))
+		Expect(state.EmulatedTPM).To(BeTrue())
+		Expect(state.EmulatedTPMSeed).To(Equal(int64(10)))
+	})
+
+	It("returns plain authentication on auth=mac registration", func() {
+		reg = elementalv1.Registration{
+			Auth: "mac",
+		}
+
+		auth, err := getAuthenticator(reg, state)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(auth.GetName()).To(Equal("Plain"))
+	})
+
+	It("returns plain authentication on auth=sys-uuid registration", func() {
+		reg = elementalv1.Registration{
+			Auth: "sys-uuid",
+		}
+
+		auth, err := getAuthenticator(reg, state)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(auth.GetName()).To(Equal("Plain"))
+	})
+
+	It("returns error on unknown authentication", func() {
+		reg = elementalv1.Registration{
+			Auth: "unknown",
+		}
+
+		_, err := getAuthenticator(reg, state)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unsupported authentication"))
+	})
+})

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -675,7 +675,7 @@ func TestRegistrationMsgUpdate(t *testing.T) {
 			header := http.Header{}
 			header.Add("Authorization", fmt.Sprintf("Bearer TPM%s", tc.machineName))
 
-			ws, _, err := websocket.DefaultDialer.Dial(url, header)
+			ws, _, _ := websocket.DefaultDialer.Dial(url, header)
 			defer ws.Close()
 
 			// Read MsgReady
@@ -815,8 +815,6 @@ type FakeAuthServer struct {
 // set to the machine-name from the URL.
 func (a *FakeAuthServer) Authenticate(conn *websocket.Conn, req *http.Request, registerNamespace string) (*elementalv1.MachineInventory, bool, error) {
 	token := path.Base(req.URL.Path)
-	escapedToken := strings.Replace(token, "\n", "", -1)
-	escapedToken = strings.Replace(escapedToken, "\r", "", -1)
 
 	// A zero CreationTimestamp implies the MachineInventory is new
 	creationTimestamp := metav1.Time{}

--- a/pkg/server/api_seedimage_test.go
+++ b/pkg/server/api_seedimage_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"gotest.tools/v3/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const existingToken = "l6mf7sfx4wbvhm8fcmbnlznsczfgm7q7f9cz4kfbkg9k4r92k9kwqc"
+
+func TestApiSeedImage(t *testing.T) {
+	server := NewInventoryServer(&FakeAuthServer{})
+	loadSeedImageResources(t, server)
+
+	testCases := []struct {
+		token        string
+		errMsg       string
+		splittedPath []string
+		shouldPass   bool
+	}{
+		{existingToken, "", nil, true},
+		{"notExisting", "failed to find seed image with token path", nil, false},
+		{"wrongSplittedPath", "unexpected path", []string{"tooshort"}, false},
+		{"notReady", "is not ready", nil, false},
+		{"noMatchingService", "failed to get service for seed image", nil, false},
+	}
+
+	for _, test := range testCases {
+		t.Logf("Testing token %s\n", test.token)
+		req := httptest.NewRequest(
+			"GET",
+			fmt.Sprintf("%s/%s", "http://localhost/elemental/seedimage/", test.token),
+			nil)
+		resp := httptest.NewRecorder()
+		splittedPath := test.splittedPath
+		if splittedPath == nil {
+			splittedPath = []string{"seedimage", test.token}
+		}
+
+		err := server.apiSeedImage(resp, req, splittedPath)
+
+		if test.shouldPass {
+			assert.NilError(t, err, err)
+		} else {
+			assert.ErrorContains(t, err, test.errMsg, err)
+		}
+	}
+}
+func TestGetSeedImage(t *testing.T) {
+
+	testCases := []struct {
+		token      string
+		errMsg     string
+		shouldPass bool
+	}{
+		{existingToken, "", true},
+		{"notExisting", "failed to find seed image with token path notExisting", false},
+		{"notReady", "seedimage fleet-default/beta is not ready", false},
+		{"\r\nnoMatchingService\n\r", "", true},
+	}
+
+	server := NewInventoryServer(&FakeAuthServer{})
+	loadSeedImageResources(t, server)
+
+	for _, test := range testCases {
+		t.Logf("Testing token %s\n", test.token)
+
+		foundSeedImage, err := server.getSeedImage(test.token)
+		if test.shouldPass {
+			assert.NilError(t, err, err)
+			escapedToken := strings.Replace(test.token, "\n", "", -1)
+			escapedToken = strings.Replace(escapedToken, "\r", "", -1)
+			assert.Equal(t, foundSeedImage.Status.DownloadToken, escapedToken)
+		} else {
+			assert.Error(t, err, test.errMsg)
+		}
+	}
+}
+
+func loadSeedImageResources(t *testing.T, server *InventoryServer) {
+	t.Helper()
+	server.Client.Create(context.Background(), &elementalv1.SeedImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alpha",
+			Namespace: "fleet-default",
+		},
+		Status: elementalv1.SeedImageStatus{
+			DownloadToken: existingToken,
+		},
+	})
+
+	server.Client.Create(context.Background(), &elementalv1.SeedImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "beta",
+			Namespace: "fleet-default",
+		},
+		Status: elementalv1.SeedImageStatus{
+			DownloadToken: "notReady",
+			Conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionFalse},
+			},
+		},
+	})
+
+	server.Client.Create(context.Background(), &elementalv1.SeedImage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gamma",
+			Namespace: "fleet-default",
+		},
+		Status: elementalv1.SeedImageStatus{
+			DownloadToken: "noMatchingService",
+		},
+	})
+
+	server.Client.Create(context.TODO(), &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "alpha",
+			Namespace: "fleet-default",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "localhost",
+		},
+	})
+}


### PR DESCRIPTION
This PR start adding some tests to cover the registration code.
The tests require a HTTP Mock server. Checked the promising [Gomega ghttp package](https://onsi.github.io/gomega/#codeghttpcode-testing-http-clients) but unfortunately we need an HTTP server that supports websocket upgrades.
So, ended up with an httptest.Server{} upgraded to websocket, used in the test just as an echo server.

There is also a commit adding some tests for the seedimage API: the tests there are not using ginkgo, but are more coherent with the tests running on the register-api section (probably we should covert all).

While there is still much more code to be covered for the registration part, this PR is a nice starting point (or so I hope 😆 ).

Related to https://github.com/rancher/elemental-operator/issues/454
