### PR TITLE
chart: add chart name and version to the operator deployment

### DIFF
--- a/.obs/chartfile/operator/templates/deployment.yaml
+++ b/.obs/chartfile/operator/templates/deployment.yaml
@@ -1,6 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kuberentes.io/version: {{ .Chart.Version }}
   name: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicas }}


### PR DESCRIPTION
When installing the chart, the deployment would render as:
```
apiVersion: apps/v1    
kind: Deployment
metadata:
  labels:
    app.kubernetes.io/name: elemental-operator
    app.kuberentes.io/version: 1.6.0
  name: elemental-operator                                                     
spec:                                                                          
  replicas: 1                
  selector:
    matchLabels:
[...]
```

Fixes #691 