### PR TITLE
Add read permission to GlobalRole

### DIFF
--- a/.obs/chartfile/operator/templates/globalrole.yaml
+++ b/.obs/chartfile/operator/templates/globalrole.yaml
@@ -14,3 +14,9 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - catalog.cattle.io
+  resources:
+  - apps
+  verbs:
+  - read


### PR DESCRIPTION
Add read permission for apps.catalog.cattle.io to elemental-operator global role.

This is used by the UI to read the installed elemental version for feature flagging.