### PR TITLE
Seedimage: use a ClusterIP Service and clean it up immediately when not needed.

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -898,7 +898,6 @@ func fillBuildImageService(name, namespace string) *corev1.Service {
 					Port:     80,
 				},
 			},
-			Type: corev1.ServiceTypeNodePort,
 		},
 	}
 


### PR DESCRIPTION
When building an ISO, we create a Pod and a Service to expose the built
ISO when ready.
The link to the ISO is then exposed through the Elemental Operator
Deployment, that acts as an Ingress.
The Service we create to expose the Pod port is of type NodePort: this
is not needed,is just a leftover from the initial implementations, where
we usede to expose a "direct" link to the Pod.
No need to keep a NodePort service now, let's have a ClusterIP Service
type instead.

Fixes https://github.com/rancher/elemental-operator/issues/705