### PR TITLE
[v1.5.x][BACKPORT] seedimage: use ClusterIP Services (#709)

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -898,7 +898,6 @@ func fillBuildImageService(name, namespace string) *corev1.Service {
 					Port:     80,
 				},
 			},
-			Type: corev1.ServiceTypeNodePort,
 		},
 	}
 


### PR DESCRIPTION
backport of #709 

----

When building an ISO, we create a Pod and a Service to expose the built ISO when ready.
The link to the ISO is then exposed through the Elemental Operator Deployment, that acts as an Ingress.
The Service we create to expose the Pod port is of type NodePort: this is not needed,is just a leftover from the initial implementations, where we usede to expose a "direct" link to the Pod.
No need to keep a NodePort service now, let's have a ClusterIP Service type instead.

Fixes: https://github.com/rancher/elemental-operator/issues/705

Signed-off-by: Francesco Giudici <francesco.giudici@suse.com>
(cherry picked from commit a43c150c82dae57de29dd386455e096b7903e17d)