### PR TITLE
Prevent system-upgrade-controller from using dotted names

### DIFF
--- a/controllers/managedosimage_controller_test.go
+++ b/controllers/managedosimage_controller_test.go
@@ -160,6 +160,18 @@ var _ = Describe("newFleetBundleResources", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(bundleResources).To(BeNil())
 	})
+
+	It("should convert ManagedOSImage name to DNS Label standard", func() {
+		managedOSImage.Name = "test.name"
+		bundleResources, err := r.newFleetBundleResources(ctx, managedOSImage)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-28ceb391618a.yaml"))
+		Expect(bundleResources[1].Name).To(Equal("ClusterRoleBinding--os-upgrader-test-name-cc7ce4275b54.yaml"))
+		Expect(bundleResources[2].Name).To(Equal("ServiceAccount-cattle-system-os-upgrader-test-name-08929531f5c0.yaml"))
+		Expect(bundleResources[3].Name).To(Equal("Secret-cattle-system-os-upgrader-test-name-52e9d8e041f4.yaml"))
+		Expect(bundleResources[4].Name).To(Equal("Plan-cattle-system-os-upgrader-test-name-24d63a562894.yaml"))
+	})
 })
 
 var _ = Describe("createFleetBundle", func() {
@@ -449,5 +461,17 @@ var _ = Describe("getImageVersion", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(version).Should(Equal("latest"))
 		Expect(image).Should(Equal(osImage.Spec.OSImage))
+	})
+})
+
+var _ = Describe("Plan naming", func() {
+	It("should replace invalid characters with -", func() {
+		input := "-my.invalid!name@"
+		wanted := "my-invalid-name"
+		Expect(toDNSLabel(input)).To(Equal(wanted))
+	})
+	It("should not replace valid strings", func() {
+		wanted := "my-valid-name"
+		Expect(toDNSLabel(wanted)).To(Equal(wanted))
 	})
 })


### PR DESCRIPTION
This should address a problem when using dots on the `ManagedOSImage` name.

For example you could use `update-to-2.0.2` when creating a new Upgrade Group from the Elemental UI, and this is perfectly valid. 

However, at the end of the upgrade process, the system-upgrade-controller will re-use this name to set the upgrade Pod's Volume, which must be in DNS Label standard (no dots allowed). 

```
Invalid value: \"secret-os-upgrader-update-to-2.0.2\": must not contain dots,
```

This PR introduces a simple conversion to DNS Label standard, which should be safe to perform and doesn't bother the user.