### PR TITLE
chart: add chart name and version to the operator deployment (#694)

### DIFF
--- a/.obs/chartfile/operator/templates/deployment.yaml
+++ b/.obs/chartfile/operator/templates/deployment.yaml
@@ -1,6 +1,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kuberentes.io/version: {{ .Chart.Version }}
   name: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicas }}


### PR DESCRIPTION
Re-adding this commit as those labels are part of the recommended labels for a deployment resource. So even if in the future this is not a strict requirement from the UI I think it is a good practice to keep them.

This also keeps backward compatibility, fixes rancher/elemental-ui#178