### PR TITLE
chart: fix upstream-version metadata

### DIFF
--- a/.obs/chartfile/operator/Chart.yaml
+++ b/.obs/chartfile/operator/Chart.yaml
@@ -21,4 +21,4 @@ annotations:
   catalog.cattle.io/release-name: elemental-operator
   catalog.cattle.io/scope: management
   catalog.cattle.io/type: cluster-tool
-  catalog.cattle.io/upstream-version: "%VERSION"
+  catalog.cattle.io/upstream-version: "%VERSION%"


### PR DESCRIPTION
`upstream-version` metadata is wrong:
```yaml
apiVersion: elemental.cattle.io/v1beta1
kind: Metadata
metadata:
  [...]
spec:
  annotations:
    catalog.cattle.io/auto-install: elemental-operator-crds=match
    [...]
    catalog.cattle.io/upstream-version: '%VERSION'
  appVersion: 1.7.0
```