### PR TITLE
Allow cross build of seed-image ISOs

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -649,10 +649,6 @@ func defaultInitContainers(seedImg *elementalv1.SeedImage, buildImg string, pull
 		return defaultRawInitContainers(seedImg, buildImg, pullPolicy)
 	}
 
-	if seedImg.Spec.TargetPlatform != "" {
-		return crossIsoInitContainers(seedImg, buildImg, pullPolicy)
-	}
-
 	return defaultIsoInitContainers(seedImg, buildImg, pullPolicy)
 }
 
@@ -699,69 +695,6 @@ func defaultRawInitContainers(seedImg *elementalv1.SeedImage, buildImg string, p
 	}
 }
 
-func crossIsoInitContainers(seedImg *elementalv1.SeedImage, buildImg string, pullPolicy corev1.PullPolicy) []corev1.Container {
-	const baseIsoPath = "/iso/base.iso"
-
-	containers := []corev1.Container{}
-	buildCommands := []string{
-		fmt.Sprintf("xorriso -indev %s -outdev /iso/$(ELEMENTAL_OUTPUT_NAME) -map /overlay/reg/livecd-cloud-config.yaml /livecd-cloud-config.yaml -map /overlay/iso-config/cloud-config.yaml /iso-config/cloud-config.yaml -boot_image any replay", baseIsoPath),
-		fmt.Sprintf("rm -rf %s", baseIsoPath),
-	}
-
-	if util.IsHTTP(seedImg.Spec.BaseImage) {
-		buildCommands = append([]string{fmt.Sprintf("curl -Lo %s %s", baseIsoPath, seedImg.Spec.BaseImage)}, buildCommands...)
-	} else {
-		// If baseImg is not an HTTP url assume it is an image reference
-		containers = append(
-			containers, corev1.Container{
-				Name:            "baseiso",
-				Image:           buildImg,
-				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"/bin/bash", "-c"},
-				Args:            []string{fmt.Sprintf("mkdir /work && elemental pull-image --platform=%s %s /work && cp /work/elemental-iso/*.iso %s", seedImg.Spec.TargetPlatform, seedImg.Spec.BaseImage, baseIsoPath)},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "iso-storage",
-						MountPath: "/iso",
-					},
-				},
-			},
-		)
-	}
-
-	containers = append(
-		containers, corev1.Container{
-			Name:            "build",
-			Image:           buildImg,
-			ImagePullPolicy: pullPolicy,
-			Command:         []string{"/bin/bash", "-c"},
-			Args:            []string{strings.Join(buildCommands, " && ")},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "iso-storage",
-					MountPath: "/iso",
-				}, {
-					Name:      "config-map",
-					MountPath: "/overlay",
-				},
-			},
-			Env: defaultEnvVars(seedImg.Name),
-		},
-	)
-
-	// Make sure the pod starts starts having enough disk for the maximum volume size
-	// volume size just represents a maximum it is not computed to schedule pods.
-	// To ensure there is enough local disk space we add a storage requirement to the first
-	// init container of the pod.
-	containers[0].Resources = corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceEphemeralStorage: seedImg.Spec.Size,
-		},
-	}
-
-	return containers
-}
-
 func defaultIsoInitContainers(seedImg *elementalv1.SeedImage, buildImg string, pullPolicy corev1.PullPolicy) []corev1.Container {
 	const baseIsoPath = "/iso/base.iso"
 
@@ -774,14 +707,24 @@ func defaultIsoInitContainers(seedImg *elementalv1.SeedImage, buildImg string, p
 	if util.IsHTTP(seedImg.Spec.BaseImage) {
 		buildCommands = append([]string{fmt.Sprintf("curl -Lo %s %s", baseIsoPath, seedImg.Spec.BaseImage)}, buildCommands...)
 	} else {
+		command := []string{"busybox", "sh", "-c"}
+		args := []string{fmt.Sprintf("busybox cp /elemental-iso/*.iso %s", baseIsoPath)}
+		image := seedImg.Spec.BaseImage
+
+		if seedImg.Spec.TargetPlatform != "" {
+			image = buildImg
+			command = []string{"/bin/bash", "-c"}
+			args = []string{fmt.Sprintf("mkdir /work && elemental pull-image --platform=%s %s /work && cp /work/elemental-iso/*.iso %s", seedImg.Spec.TargetPlatform, seedImg.Spec.BaseImage, baseIsoPath)}
+		}
+
 		// If baseImg is not an HTTP url assume it is an image reference
 		containers = append(
 			containers, corev1.Container{
 				Name:            "baseiso",
-				Image:           seedImg.Spec.BaseImage,
+				Image:           image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"busybox", "sh", "-c"},
-				Args:            []string{fmt.Sprintf("busybox cp /elemental-iso/*.iso %s", baseIsoPath)},
+				Command:         command,
+				Args:            args,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      "iso-storage",

--- a/controllers/seedimage_controller_test.go
+++ b/controllers/seedimage_controller_test.go
@@ -830,4 +830,21 @@ var _ = Describe("fillBuildImagePod", func() {
 		Expect(pod.Spec.InitContainers[0].Image).To(Equal(buildImg))
 		Expect(pod.Spec.InitContainers[0].ImagePullPolicy).To(Equal(corev1.PullNever))
 	})
+
+	It("should use targetPlatform when provided", func() {
+		defaultBuildImg := "default-builder:latest"
+		seedImg := &elementalv1.SeedImage{
+			Spec: elementalv1.SeedImageSpec{
+				BaseImage:      "elemental/default-iso:latest",
+				TargetPlatform: "linux/riscv64",
+			},
+		}
+
+		pod := fillBuildImagePod(seedImg, defaultBuildImg, corev1.PullNever)
+
+		Expect(len(pod.Spec.InitContainers)).To(Equal(2))
+		Expect(pod.Spec.InitContainers[0].Image).To(Equal(defaultBuildImg))
+		Expect(pod.Spec.InitContainers[0].Args[0]).To(ContainSubstring("elemental pull-image --platform=linux/riscv64"))
+
+	})
 })


### PR DESCRIPTION
This commit makes use of the targetPlatform field on the seedImage spec
to allow building ISOs for different architectures.

It does this by spawning the initContainer using the seedImageBuilder
image and using the `elemental pull-image --platform=` command to
download the correct ISO and copies it to the attached volume.

One drawback of this approach is we don't get the caching of images in
the container runtime that we get when building natively.

Signed-off-by: Fredrik Lönnegren <fredrik.lonnegren@suse.com>
