### PR TITLE
Deprecate install yq action

### DIFF
--- a/.github/actions/chart/action.yaml
+++ b/.github/actions/chart/action.yaml
@@ -10,8 +10,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install yq
-      uses: mikefarah/yq@v4.28.2
     - name: Set image repositories
       id: set_repo
       shell: bash

--- a/.github/workflows/airgap-test.yaml
+++ b/.github/workflows/airgap-test.yaml
@@ -17,8 +17,6 @@ jobs:
       timeout-minutes: 12
     - name: Install Helm
       run: sudo snap install helm --classic
-    - name: Install yq
-      uses: mikefarah/yq@v4.28.2
     - name: Install jq
       run: sudo apt install jq -y
     - name: Run test


### PR DESCRIPTION
This should no longer be needed, as it's included in the runner images: https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-yq.sh