### PR TITLE
Added the ability to create a node reset marker for unmanaged hosts

### DIFF
--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -53,7 +53,7 @@ import (
 const adoptionTimeout = 5
 
 const LocalResetPlanPath = "/oem/reset-cloud-config.yaml"
-const LocalResetUnmanagedMarker = "/etc/rancher/.unmanaged_reset"
+const LocalResetUnmanagedMarker = "/var/lib/elemental/.unmanaged_reset"
 
 // MachineInventoryReconciler reconciles a MachineInventory object.
 type MachineInventoryReconciler struct {


### PR DESCRIPTION
This PR adds functionality that enables unmanaged OS nodes in Elemental to utilise the reset functionality of the Elemental operator. The functionality here enables an OS-agnostic approach, where it simply leaves a marker on the underlying host when reset via Rancher is explicitly desired in the event of either a cluster deletion, node deletion from cluster, or node deletion from the machine inventory. This PR doesn't add the actual handling of the cleanup here, and leaves that for the user in question, e.g. triggering via systemd cleanup script. This enables the user to handle the node cleanup via whatever means they desire, but knowing that it was originally triggered by Rancher/Elemental, and thus data cleanup is likely desired, but isn't controlled by Elemental.

This patch requires the user to have both the following annotations set for the functionality to trigger:

```
elemental.cattle.io/os.unmanaged: 'true'
elemental.cattle.io/resettable: 'true'
```