### PR TITLE
register: don't send new Disks and Controllers data

### DIFF
--- a/pkg/hostinfo/hostinfo.go
+++ b/pkg/hostinfo/hostinfo.go
@@ -220,3 +220,19 @@ func FillData(data []byte) (map[string]interface{}, error) {
 
 	return labels, nil
 }
+
+// Prune() filters out new Disks and Controllers introduced in ghw/pkg/block > 0.9.0
+// see: https://github.com/rancher/elemental-operator/issues/733
+func Prune(data *HostInfo) {
+	prunedDisks := []*block.Disk{}
+	for i := 0; i < len(data.Block.Disks); i++ {
+		if data.Block.Disks[i].DriveType > block.DRIVE_TYPE_SSD {
+			continue
+		}
+		if data.Block.Disks[i].StorageController > block.STORAGE_CONTROLLER_MMC {
+			continue
+		}
+		prunedDisks = append(prunedDisks, data.Block.Disks[i])
+	}
+	data.Block.Disks = prunedDisks
+}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -267,6 +267,9 @@ func sendSystemData(conn *websocket.Conn) error {
 	if err != nil {
 		return fmt.Errorf("reading system data: %w", err)
 	}
+	// preserve compatibility with older Elemental Operators
+	hostinfo.Prune(data)
+
 	err = SendJSONData(conn, MsgSystemData, data)
 	if err != nil {
 		log.Debugf("system data:\n%s", litter.Sdump(data))


### PR DESCRIPTION
The newer versions of jaypipes/ghw include a new type of Disk and Controller in the Blocks section.

We use the library json serialization functionality: the deserialization function of the older version of the library (0.9.0) would error out when trying to decode serialized data of newer versions if they include the new "virtual" drive or the new "loop" controller. For now, just remove those devices.
This is a quick WA that can be managed on the registration client only.
Proper fix will be to better deal with this kind of errors on the elemental-operator side avoiding tearing down the registration process.

Related to: https://github.com/rancher/elemental-operator/issues/733