### PR TITLE
Let elemental-register digest system hardware data

### DIFF
--- a/pkg/hostinfo/hostinfo.go
+++ b/pkg/hostinfo/hostinfo.go
@@ -233,3 +233,20 @@ func ExtractLabels(systemData HostInfo) (map[string]interface{}, error) {
 
 	return labels, nil
 }
+
+// Deprecated. Remove me together with 'MsgSystemData' type.
+// Prune() filters out new Disks and Controllers introduced in ghw/pkg/block > 0.9.0
+// see: https://github.com/rancher/elemental-operator/issues/733
+func Prune(data *HostInfo) {
+	prunedDisks := []*block.Disk{}
+	for i := 0; i < len(data.Block.Disks); i++ {
+		if data.Block.Disks[i].DriveType > block.DRIVE_TYPE_SSD {
+			continue
+		}
+		if data.Block.Disks[i].StorageController > block.STORAGE_CONTROLLER_MMC {
+			continue
+		}
+		prunedDisks = append(prunedDisks, data.Block.Disks[i])
+	}
+	data.Block.Disks = prunedDisks
+}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -108,7 +108,7 @@ func (r *client) Register(reg elementalv1.Registration, caCert []byte, state *St
 			return nil, fmt.Errorf("failed to send SMBIOS data: %w", err)
 		}
 
-		if protoVersion >= MsgSystemDataNG {
+		if protoVersion >= MsgSystemDataV2 {
 			log.Infof("Send system data")
 			if err := sendSystemDataNG(conn); err != nil {
 				return nil, fmt.Errorf("failed to send system data: %w", err)
@@ -280,7 +280,7 @@ func sendSystemDataNG(conn *websocket.Conn) error {
 		return fmt.Errorf("extracting labels from system data: %w", err)
 	}
 
-	err = SendJSONData(conn, MsgSystemDataNG, labels)
+	err = SendJSONData(conn, MsgSystemDataV2, labels)
 	if err != nil {
 		log.Debugf("system data:\n%s", litter.Sdump(data))
 		return err

--- a/pkg/register/websocket.go
+++ b/pkg/register/websocket.go
@@ -40,8 +40,8 @@ const (
 	MsgError                          // v1.1.1
 	MsgAnnotations                    // v1.1.4
 	MsgUpdate                         // v1.2.6
-	MsgSystemDataNG                   // v1.6.0
-	MsgLast         = MsgSystemDataNG // MsgLast must point to the last message
+	MsgSystemDataV2                   // v1.6.0
+	MsgLast         = MsgSystemDataV2 // MsgLast must point to the last message
 )
 
 func (mt MessageType) String() string {
@@ -68,8 +68,8 @@ func (mt MessageType) String() string {
 		return "Annotations"
 	case MsgUpdate:
 		return "Update"
-	case MsgSystemDataNG:
-		return "SystemDataNG"
+	case MsgSystemDataV2:
+		return "SystemDataV2"
 	default:
 		return "Unknown"
 	}

--- a/pkg/register/websocket.go
+++ b/pkg/register/websocket.go
@@ -33,14 +33,15 @@ const (
 	MsgReady
 	MsgSmbios
 	MsgLabels
-	MsgGet                     // v0.5.0
-	MsgVersion                 // v1.1.0
-	MsgSystemData              // v1.1.1
-	MsgConfig                  // v1.1.1
-	MsgError                   // v1.1.1
-	MsgAnnotations             // v1.1.4
-	MsgUpdate                  // v1.2.6
-	MsgLast        = MsgUpdate // MsgLast must point to the last message
+	MsgGet                            // v0.5.0
+	MsgVersion                        // v1.1.0
+	MsgSystemData                     // v1.1.1
+	MsgConfig                         // v1.1.1
+	MsgError                          // v1.1.1
+	MsgAnnotations                    // v1.1.4
+	MsgUpdate                         // v1.2.6
+	MsgSystemDataNG                   // v1.6.0
+	MsgLast         = MsgSystemDataNG // MsgLast must point to the last message
 )
 
 func (mt MessageType) String() string {
@@ -67,6 +68,8 @@ func (mt MessageType) String() string {
 		return "Annotations"
 	case MsgUpdate:
 		return "Update"
+	case MsgSystemDataNG:
+		return "SystemDataNG"
 	default:
 		return "Unknown"
 	}

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -294,7 +294,11 @@ func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elementalv1
 			if err != nil {
 				return fmt.Errorf("failed to extract labels from system data: %w", err)
 			}
-
+		case register.MsgSystemDataNG:
+			err = updateInventoryFromSystemDataNG(data, inventory, registration)
+			if err != nil {
+				return fmt.Errorf("failed to extract labels from system data: %w", err)
+			}
 		default:
 			return fmt.Errorf("got unexpected message: %s", msgType)
 		}
@@ -436,6 +440,18 @@ func updateInventoryFromSMBIOSData(data []byte, mInventory *elementalv1.MachineI
 	return nil
 }
 
+// updateInventoryFromSystemDataNG receives digested hardware labels from the client
+func updateInventoryFromSystemDataNG(data []byte, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
+	labels := map[string]interface{}{}
+
+	if err := json.Unmarshal(data, &labels); err != nil {
+		return fmt.Errorf("unmarshalling system data labels payload: %w", err)
+	}
+
+	return sanitizeSystemDataLabels(labels, inv, reg)
+}
+
+// Deprecated. Remove me together with 'MsgSystemData' type.
 // updateInventoryFromSystemData creates labels in the inventory based on the hardware information
 func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
 	log.Infof("Adding labels from system data")
@@ -445,6 +461,10 @@ func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventor
 		return err
 	}
 
+	return sanitizeSystemDataLabels(labels, inv, reg)
+}
+
+func sanitizeSystemDataLabels(labels map[string]interface{}, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
 	// Also available but not used:
 	// systemData.Product -> name, vendor, serial,uuid,sku,version. Kind of smbios data
 	// systemData.BIOS -> info about the bios. Useless IMO

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -294,7 +294,7 @@ func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elementalv1
 			if err != nil {
 				return fmt.Errorf("failed to extract labels from system data: %w", err)
 			}
-		case register.MsgSystemDataNG:
+		case register.MsgSystemDataV2:
 			err = updateInventoryFromSystemDataNG(data, inventory, registration)
 			if err != nil {
 				return fmt.Errorf("failed to extract labels from system data: %w", err)

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -50,6 +50,75 @@ import (
 	elementalruntime "github.com/rancher/elemental-operator/pkg/runtime"
 )
 
+var (
+	systemDataLabelsRegistrationFixture = &elementalv1.MachineRegistration{
+		Spec: elementalv1.MachineRegistrationSpec{
+			MachineInventoryLabels: map[string]string{
+				"elemental.cattle.io/Hostname":               "${System Data/Runtime/Hostname}",
+				"elemental.cattle.io/TotalMemory":            "${System Data/Memory/Total Physical Bytes}",
+				"elemental.cattle.io/AvailableMemory":        "${System Data/Memory/Total Usable Bytes}",
+				"elemental.cattle.io/CpuTotalCores":          "${System Data/CPU/Total Cores}",
+				"elemental.cattle.io/CpuTotalThreads":        "${System Data/CPU/Total Threads}",
+				"elemental.cattle.io/NetIfacesNumber":        "${System Data/Network/Number Interfaces}",
+				"elemental.cattle.io/NetIface0-Name":         "${System Data/Network/myNic1/Name}",
+				"elemental.cattle.io/NetIface0-MAC":          "${System Data/Network/myNic1/MacAddress}",
+				"elemental.cattle.io/NetIface0-IsVirtual":    "${System Data/Network/myNic1/IsVirtual}",
+				"elemental.cattle.io/NetIface1-Name":         "${System Data/Network/myNic2/Name}",
+				"elemental.cattle.io/BlockDevicesNumber":     "${System Data/Block Devices/Number Devices}",
+				"elemental.cattle.io/BlockDevice0-Name":      "${System Data/Block Devices/testdisk1/Name}",
+				"elemental.cattle.io/BlockDevice1-Name":      "${System Data/Block Devices/testdisk2/Name}",
+				"elemental.cattle.io/BlockDevice0-Size":      "${System Data/Block Devices/testdisk1/Size}",
+				"elemental.cattle.io/BlockDevice1-Size":      "${System Data/Block Devices/testdisk2/Size}",
+				"elemental.cattle.io/BlockDevice0-Removable": "${System Data/Block Devices/testdisk1/Removable}",
+				"elemental.cattle.io/BlockDevice1-Removable": "${System Data/Block Devices/testdisk2/Removable}",
+			},
+		},
+	}
+
+	hostInfoFixture = hostinfo.HostInfo{
+		Block: &block.Info{
+			Disks: []*block.Disk{
+				{
+					Name:        "testdisk1",
+					SizeBytes:   300,
+					IsRemovable: true,
+				},
+				{
+					Name:        "testdisk2",
+					SizeBytes:   600,
+					IsRemovable: false,
+				},
+			},
+			Partitions: nil,
+		},
+		Memory: &memory.Info{
+			Area: memory.Area{
+				TotalPhysicalBytes: 100,
+				TotalUsableBytes:   90,
+			},
+		},
+		CPU: &cpu.Info{
+			TotalCores:   300,
+			TotalThreads: 300,
+		},
+		Network: &net.Info{
+			NICs: []*net.NIC{
+				{
+					Name:       "myNic1",
+					MacAddress: "02:00:00:00:00:01",
+					IsVirtual:  true,
+				},
+				{
+					Name: "myNic2",
+				},
+			},
+		},
+		Runtime: &elementalruntime.Info{
+			Hostname: "machine-1",
+		},
+	}
+)
+
 func TestUnauthenticatedResponse(t *testing.T) {
 	testCase := []struct {
 		config *elementalv1.Config
@@ -263,76 +332,28 @@ func TestMergeInventoryLabels(t *testing.T) {
 
 func TestUpdateInventoryFromSystemData(t *testing.T) {
 	inventory := &elementalv1.MachineInventory{}
-	registration := &elementalv1.MachineRegistration{
-		Spec: elementalv1.MachineRegistrationSpec{
-			MachineInventoryLabels: map[string]string{
-				"elemental.cattle.io/Hostname":               "${System Data/Runtime/Hostname}",
-				"elemental.cattle.io/TotalMemory":            "${System Data/Memory/Total Physical Bytes}",
-				"elemental.cattle.io/AvailableMemory":        "${System Data/Memory/Total Usable Bytes}",
-				"elemental.cattle.io/CpuTotalCores":          "${System Data/CPU/Total Cores}",
-				"elemental.cattle.io/CpuTotalThreads":        "${System Data/CPU/Total Threads}",
-				"elemental.cattle.io/NetIfacesNumber":        "${System Data/Network/Number Interfaces}",
-				"elemental.cattle.io/NetIface0-Name":         "${System Data/Network/myNic1/Name}",
-				"elemental.cattle.io/NetIface0-MAC":          "${System Data/Network/myNic1/MacAddress}",
-				"elemental.cattle.io/NetIface0-IsVirtual":    "${System Data/Network/myNic1/IsVirtual}",
-				"elemental.cattle.io/NetIface1-Name":         "${System Data/Network/myNic2/Name}",
-				"elemental.cattle.io/BlockDevicesNumber":     "${System Data/Block Devices/Number Devices}",
-				"elemental.cattle.io/BlockDevice0-Name":      "${System Data/Block Devices/testdisk1/Name}",
-				"elemental.cattle.io/BlockDevice1-Name":      "${System Data/Block Devices/testdisk2/Name}",
-				"elemental.cattle.io/BlockDevice0-Size":      "${System Data/Block Devices/testdisk1/Size}",
-				"elemental.cattle.io/BlockDevice1-Size":      "${System Data/Block Devices/testdisk2/Size}",
-				"elemental.cattle.io/BlockDevice0-Removable": "${System Data/Block Devices/testdisk1/Removable}",
-				"elemental.cattle.io/BlockDevice1-Removable": "${System Data/Block Devices/testdisk2/Removable}",
-			},
-		},
-	}
-	data := hostinfo.HostInfo{
-		Block: &block.Info{
-			Disks: []*block.Disk{
-				{
-					Name:        "testdisk1",
-					SizeBytes:   300,
-					IsRemovable: true,
-				},
-				{
-					Name:        "testdisk2",
-					SizeBytes:   600,
-					IsRemovable: false,
-				},
-			},
-			Partitions: nil,
-		},
-		Memory: &memory.Info{
-			Area: memory.Area{
-				TotalPhysicalBytes: 100,
-				TotalUsableBytes:   90,
-			},
-		},
-		CPU: &cpu.Info{
-			TotalCores:   300,
-			TotalThreads: 300,
-		},
-		Network: &net.Info{
-			NICs: []*net.NIC{
-				{
-					Name:       "myNic1",
-					MacAddress: "02:00:00:00:00:01",
-					IsVirtual:  true,
-				},
-				{
-					Name: "myNic2",
-				},
-			},
-		},
-		Runtime: &elementalruntime.Info{
-			Hostname: "machine-1",
-		},
-	}
+	encodedData, err := json.Marshal(hostInfoFixture)
+	assert.NilError(t, err)
+	err = updateInventoryFromSystemData(encodedData, inventory, systemDataLabelsRegistrationFixture)
+	assert.NilError(t, err)
+
+	assertSystemDataLabels(t, inventory)
+}
+
+func TestUpdateInventoryFromSystemDataNG(t *testing.T) {
+	inventory := &elementalv1.MachineInventory{}
+	data, err := hostinfo.ExtractLabels(hostInfoFixture)
+	assert.NilError(t, err)
 	encodedData, err := json.Marshal(data)
 	assert.NilError(t, err)
-	err = updateInventoryFromSystemData(encodedData, inventory, registration)
+	err = updateInventoryFromSystemDataNG(encodedData, inventory, systemDataLabelsRegistrationFixture)
 	assert.NilError(t, err)
-	// Check that the labels we properly added to the inventory
+	assertSystemDataLabels(t, inventory)
+}
+
+// Check that the labels we properly added to the inventory
+func assertSystemDataLabels(t *testing.T, inventory *elementalv1.MachineInventory) {
+	t.Helper()
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/Hostname"], "machine-1")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/TotalMemory"], "100")
 	assert.Equal(t, inventory.Labels["elemental.cattle.io/TotalMemory"], "100")


### PR DESCRIPTION
This should remove the `elemental-operator` dependency on ghw library, making the `elemental-register` client do the conversion. 

The implementation is backward compatible, tested it with a `1.4.2` version of the elemental-register and it works as expected.

This is a solution for #733 and if integrated, it should be backported to 1.6.x in order to close that issue.