### PR TITLE
Flag no longer in sync ManagedOSVersions

### DIFF
--- a/api/v1beta1/common_consts.go
+++ b/api/v1beta1/common_consts.go
@@ -28,6 +28,7 @@ const (
 
 	// ElementalManagedOSVersionNoLongerSyncedAnnotation is used to mark a no longer in sync ManagedOSVersion, this highlight it can be deleted.
 	ElementalManagedOSVersionNoLongerSyncedAnnotation = "elemental.cattle.io/channel-no-longer-in-sync"
+	ElementalManagedOSVersionNoLongerSyncedValue      = "true"
 
 	// SASecretSuffix is the suffix used to name registration service account's token secret
 	SASecretSuffix = "-token"

--- a/api/v1beta1/common_consts.go
+++ b/api/v1beta1/common_consts.go
@@ -20,8 +20,14 @@ const (
 	// ElementalManagedLabel label used to put on resources managed by the elemental operator.
 	ElementalManagedLabel = "elemental.cattle.io/managed"
 
-	// ElementalManagedLabel label used to put on resources managed by the elemental operator.
+	// ElementalManagedOSVersionChannelLabel is used to filter a set of ManagedOSVersions given the channel they originate from.
 	ElementalManagedOSVersionChannelLabel = "elemental.cattle.io/channel"
+
+	// ElementalManagedOSVersionChannelLastSyncAnnotation reports when a ManagedOSVersion was last synced from a channel.
+	ElementalManagedOSVersionChannelLastSyncAnnotation = "elemental.cattle.io/channel-last-sync"
+
+	// ElementalManagedOSVersionNoLongerSyncedAnnotation is used to mark a no longer in sync ManagedOSVersion, this highlight it can be deleted.
+	ElementalManagedOSVersionNoLongerSyncedAnnotation = "elemental.cattle.io/channel-no-longer-in-sync"
 
 	// SASecretSuffix is the suffix used to name registration service account's token secret
 	SASecretSuffix = "-token"

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -330,7 +330,6 @@ func (r *ManagedOSVersionChannelReconciler) createManagedOSVersions(ctx context.
 		}
 		vcpy.ObjectMeta.Annotations = map[string]string{
 			elementalv1.ElementalManagedOSVersionChannelLastSyncAnnotation: syncTime,
-			elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation:  "false",
 		}
 
 		if ch.Spec.UpgradeContainer != nil {
@@ -370,7 +369,7 @@ func (r *ManagedOSVersionChannelReconciler) createManagedOSVersions(ctx context.
 		if lastSyncTime, found := version.Annotations[elementalv1.ElementalManagedOSVersionChannelLastSyncAnnotation]; !found || (lastSyncTime != syncTime) {
 			logger.Info("ManagedOSVersion no longer synced through this channel", "name", version.Name)
 			patchBase := client.MergeFrom(version.DeepCopy())
-			version.ObjectMeta.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation] = "true"
+			version.ObjectMeta.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation] = elementalv1.ElementalManagedOSVersionNoLongerSyncedValue
 			if err := r.Patch(ctx, version, patchBase); err != nil {
 				logger.Error(err, "Could not patch ManagedOSVersion as no longer in sync", "name", version.Name)
 				return fmt.Errorf("deprecating ManagedOSVersion '%s': %w", version.Name, err)

--- a/controllers/managedosversionchannel_controller_test.go
+++ b/controllers/managedosversionchannel_controller_test.go
@@ -656,7 +656,8 @@ var _ = Describe("managed os version channel controller integration tests", func
 			}, managedOSVersion)
 			return err == nil
 		}, 12*time.Second, 2*time.Second).Should(BeTrue())
-		Expect(managedOSVersion.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation]).To(Equal("false"))
+		_, found := managedOSVersion.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation]
+		Expect(found).To(BeFalse(), "no-longer-synced annotation must not be present when versions are actually synced")
 		Expect(managedOSVersion.Annotations[elementalv1.ElementalManagedOSVersionChannelLastSyncAnnotation]).ToNot(BeEmpty(), "Last sync annotation should contain the UTC timestamp")
 
 		// After channel update already existing versions were patched
@@ -664,7 +665,7 @@ var _ = Describe("managed os version channel controller integration tests", func
 			Name:      "v0.1.0",
 			Namespace: ch.Namespace,
 		}, managedOSVersion)).To(Succeed())
-		Expect(managedOSVersion.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation]).To(Equal("true"))
+		Expect(managedOSVersion.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation]).To(Equal(elementalv1.ElementalManagedOSVersionNoLongerSyncedValue))
 	})
 
 	It("should not reconcile again if it errors during pod lifecycle", func() {


### PR DESCRIPTION
This introduces a `elemental.cattle.io/channel-no-longer-in-sync` annotation that can be used by the UI (or by the user directly) to cleanup no longer synced versions from a channel. 

Closes #744 