### PR TITLE
Allow yip configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/cluster-api v1.6.3
 	sigs.k8s.io/controller-runtime v0.17.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -161,5 +162,4 @@ require (
 	sigs.k8s.io/cli-utils v0.28.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )


### PR DESCRIPTION
Closes rancher/elemental#1437

@davidcassany This is what I had in mind. 

(Still have to test it, but it should work)

Whenever the user can define a "cloud config", the elemental-operator codebase always assumed it was cloud-init style, therefore it always prefixed the `#cloud-config` header. 

With this patch we try to figure out if this is a yip config (technically if at least one stage has been defined), before applying or not the  `#cloud-config` header. 

I also removed the custom mapping code and used `sigs.k8s.io/yaml` which contrary to our code, works when working with maps (as `stages` is in yip) 