### PR TITLE
Integrate a development channel in charts

### DIFF
--- a/.obs/chartfile/operator/templates/channel-dev.yaml
+++ b/.obs/chartfile/operator/templates/channel-dev.yaml
@@ -1,0 +1,14 @@
+{{ if contains "isv/rancher/elemental" .Values.registryUrl }}
+  {{ if hasPrefix "registry.opensuse.org" .Values.registryUrl }}
+# Unstable channel for isv:Rancher:Elemental OBS projects
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: unstable-channel
+  namespace: fleet-default
+spec:
+  options:
+    image: {{ .Values.registryUrl }}/rancher/elemental-unstable-channel:latest
+  type: custom
+  {{ end }}
+{{ end }}

--- a/.obs/chartfile/operator/templates/channel.yaml
+++ b/.obs/chartfile/operator/templates/channel.yaml
@@ -1,8 +1,8 @@
-{{ if and .Values.channel .Values.channel.image .Values.channel.tag }}
+{{ if and .Values.channel .Values.channel.image .Values.channel.tag .Values.channel.name }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
-  name: elemental-channel
+  name: {{ .Values.channel.name }}
   namespace: fleet-default
 spec:
   options:

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -10,7 +10,8 @@ seedImage:
   imagePullPolicy: IfNotPresent
 
 channel:
-  image: "%%IMG_REPO%%/rancher/elemental-channel"
+  name: "sle-micro-channel"
+  image: "registry.suse.com/rancher/elemental-channel"
   tag: "%VERSION%"
 
 # number of operator replicas to deploy


### PR DESCRIPTION
This is a PoC to add an unstable channel for helm builds happening at `isv:Rancher:Elemental` projects in OBS.