### PR TITLE
operator: fix ManagedOSVersionChannel sync

### DIFF
--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -367,6 +367,9 @@ func (r *ManagedOSVersionChannelReconciler) createManagedOSVersions(ctx context.
 		if lastSyncTime, found := version.Annotations[elementalv1.ElementalManagedOSVersionChannelLastSyncAnnotation]; !found || (lastSyncTime != syncTimestamp) {
 			logger.Info("ManagedOSVersion no longer synced through this channel", "name", version.Name)
 			patchBase := client.MergeFrom(version.DeepCopy())
+			if version.ObjectMeta.Annotations == nil {
+				version.ObjectMeta.Annotations = map[string]string{}
+			}
 			version.ObjectMeta.Annotations[elementalv1.ElementalManagedOSVersionNoLongerSyncedAnnotation] = elementalv1.ElementalManagedOSVersionNoLongerSyncedValue
 			if err := r.Patch(ctx, version, patchBase); err != nil {
 				logger.Error(err, "Could not patch ManagedOSVersion as no longer in sync", "name", version.Name)

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -460,6 +460,12 @@ func (r *ManagedOSVersionChannelReconciler) createSyncerPod(ctx context.Context,
 		return err
 	}
 
+	// If we don't update the LastSyncedTime on Pod creation, we will loop
+	// creating/deleting the Pod after the ManagedOSVersionChannel.spec.syncInterval
+	// see https://github.com/rancher/elemental-operator/issues/766
+	now := metav1.Now()
+	ch.Status.LastSyncedTime = &now
+
 	meta.SetStatusCondition(&ch.Status.Conditions, metav1.Condition{
 		Type:    elementalv1.ReadyCondition,
 		Reason:  elementalv1.SyncingReason,


### PR DESCRIPTION
Review the sync in the ManagedOSVersionChannel reconcile loop.

After the very fist initial sync, all subsequently channel syncs fail: fixed.
Fixes: #766 

Older resources may not have annotations yet: initialize the field.
Fixes: #767 