### PR TITLE
Remove flaky checksum test

### DIFF
--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -654,11 +654,10 @@ var _ = Describe("handle unmanaged finalizer", func() {
 		mInventory.Annotations[elementalv1.MachineInventoryOSUnmanagedAnnotation] = "true"
 		Expect(cl.Update(ctx, mInventory)).To(Succeed())
 
-		wantChecksum, wantPlan, err := r.newUnmanagedResetPlan(ctx)
+		_, wantPlan, err := r.newUnmanagedResetPlan(ctx)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check Plan status
-		Expect(mInventory.Status.Plan.Checksum).To(Equal(wantChecksum))
 		Expect(mInventory.Status.Plan.PlanSecretRef.Name).To(Equal(planSecret.Name))
 		Expect(mInventory.Status.Plan.PlanSecretRef.Namespace).To(Equal(planSecret.Namespace))
 		Expect(mInventory.Status.Plan.State).To(Equal(elementalv1.PlanState("")))


### PR DESCRIPTION
Just a little thing bugging me. 
The "unmanaged reset plan" is a simple sentinel file containing a `time.Now()` timestamp.

We didn't expose the controller's clock to make it testable, so the checksum test has chances to fail on a slow machine (precision is seconds). 

will look like: 

```
handle unmanaged finalizer [It] should update secret with reset plan when unmanaged annotation is true
/elemental-operator/controllers/machineinventory_controller_test.go:644

  [FAILED] Expected
      <string>: "cef759..."
  to equal       |
      <string>: "457f15..."
  In [It] at: /elemental-operator/controllers/machineinventory_controller_test.go:661 @ 06/21/24 13:08:13.001
```

Simplest solution is to remove this test for this plan, since the same logic is already tested by the similar "should update secret with reset plan" test. 