### PR TITLE
Add toggle to automatically delete no longer in sync versions

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -2540,6 +2540,12 @@ spec:
             type: object
           spec:
             properties:
+              deleteNoLongerInSyncVersions:
+                default: false
+                description: |-
+                  DeleteNoLongerInSyncVersions automatically deletes
+                  all no-longer-in-sync ManagedOSVersions that were created by this channel.
+                type: boolean
               options:
                 x-kubernetes-preserve-unknown-fields: true
               syncInterval:

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 
 export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CHART?=$(shell find $(ROOT_DIR) -type f  -name "elemental-operator-$(CHART_VERSION).tgz" -print)
+CHART_CRDS?=$(shell find $(ROOT_DIR) -type f  -name "elemental-operator-crds-$(CHART_VERSION).tgz" -print)
 KUBE_VERSION?="v1.27.10"
 CLUSTER_NAME?="operator-e2e"
 COMMITDATE?=$(shell git log -n1 --format="%as")
@@ -197,6 +198,7 @@ setup-full-cluster: build-docker-operator build-docker-seedimage-builder chart s
 # thus losing any registration/inventories/os CRDs already created
 reload-operator: build-docker-operator chart
 	kind load docker-image --name $(CLUSTER_NAME) ${REGISTRY_HEADER}${REPO}:${CHART_VERSION}
+	helm upgrade -n cattle-elemental-system elemental-operator-crds $(CHART_CRDS)
 	helm upgrade -n cattle-elemental-system elemental-operator $(CHART)
 
 .PHONY: vendor

--- a/api/v1beta1/managedosversionchannel_types.go
+++ b/api/v1beta1/managedosversionchannel_types.go
@@ -39,6 +39,11 @@ type ManagedOSVersionChannelSpec struct {
 	// +optional
 	// +kubebuilder:default:="1h"
 	SyncInterval string `json:"syncInterval,omitempty"`
+	// DeleteNoLongerInSyncVersions automatically deletes
+	// all no-longer-in-sync ManagedOSVersions that were created by this channel.
+	// +optional
+	// +kubebuilder:default:=false
+	DeleteNoLongerInSyncVersions bool `json:"deleteNoLongerInSyncVersions,omitempty"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +optional

--- a/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
@@ -37,6 +37,12 @@ spec:
             type: object
           spec:
             properties:
+              deleteNoLongerInSyncVersions:
+                default: false
+                description: |-
+                  DeleteNoLongerInSyncVersions automatically deletes
+                  all no-longer-in-sync ManagedOSVersions that were created by this channel.
+                type: boolean
               options:
                 x-kubernetes-preserve-unknown-fields: true
               syncInterval:

--- a/controllers/managedosversionchannel_controller.go
+++ b/controllers/managedosversionchannel_controller.go
@@ -375,6 +375,13 @@ func (r *ManagedOSVersionChannelReconciler) createManagedOSVersions(ctx context.
 				logger.Error(err, "Could not patch ManagedOSVersion as no longer in sync", "name", version.Name)
 				return fmt.Errorf("deprecating ManagedOSVersion '%s': %w", version.Name, err)
 			}
+			if ch.Spec.DeleteNoLongerInSyncVersions {
+				logger.Info("Auto-deleting no longer in sync ManagedOSVersion due to channel settings", "name", version.Name)
+				if err := r.Delete(ctx, version); err != nil {
+					logger.Error(err, "Could not auto-delete no longer in sync ManagedOSVersion")
+					return fmt.Errorf("auto-deleting ManagedOSVersion '%s': %w", version.Name, err)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Part of #759 

This introduces an option to automatically delete ManagedOSVersions that are no longer in sync with a channel.

The default value is `false` to not change the current behavior, but we can rethink it. It should be safe to enable it by default, in conjunction with #775, but it may still be unexpected for the user.