### PR TITLE
Block reinstall if crds are still pending to be deleted

### DIFF
--- a/.obs/chartfile/crds/templates/validate-no-pending-deletions.yaml
+++ b/.obs/chartfile/crds/templates/validate-no-pending-deletions.yaml
@@ -1,6 +1,17 @@
-{{- $inventoryCRD := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" .Release.Namespace "machineinventories.elemental.cattle.io" -}}
-{{- if $inventoryCRD -}}
-  {{- if $inventoryCRD.metadata.deletionTimestamp -}}
-     {{- required "CRDs from previous installations are pending to be removed (deletionTimestamp is set). Fully deleting them before (re-)installing is required" "" -}}
+{{- $crds := list
+  "machineinventories.elemental.cattle.io"
+  "machineinventoryselectors.elemental.cattle.io"
+  "machineinventoryselectortemplates.elemental.cattle.io"
+  "machineregistrations.elemental.cattle.io"
+  "managedosimages.elemental.cattle.io"
+  "managedosversionchannels.elemental.cattle.io"
+  "managedosversions.elemental.cattle.io"
+  "seedimages.elemental.cattle.io"
+  "metadatas.elemental.cattle.io"
+-}}
+{{- range $index, $crd := $crds -}}
+  {{- $obj := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" .Release.Namespace $crd -}}
+  {{- if and $obj $obj.metadata.deletionTimestamp -}}
+    {{- required "CRDs from previous installations are pending to be removed (deletionTimestamp is set). Fully deleting them before (re-)installing is required" "" -}}
   {{- end -}}
 {{- end -}}

--- a/.obs/chartfile/crds/templates/validate-no-pending-deletions.yaml
+++ b/.obs/chartfile/crds/templates/validate-no-pending-deletions.yaml
@@ -7,10 +7,10 @@
   "managedosversionchannels.elemental.cattle.io"
   "managedosversions.elemental.cattle.io"
   "seedimages.elemental.cattle.io"
-  "metadatas.elemental.cattle.io"
+  "metadata.elemental.cattle.io"
 -}}
 {{- range $index, $crd := $crds -}}
-  {{- $obj := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" .Release.Namespace $crd -}}
+  {{- $obj := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" $.Release.Namespace $crd -}}
   {{- if and $obj $obj.metadata.deletionTimestamp -}}
     {{- required "CRDs from previous installations are pending to be removed (deletionTimestamp is set). Fully deleting them before (re-)installing is required" "" -}}
   {{- end -}}

--- a/.obs/chartfile/operator/templates/validate-install-crd.yaml
+++ b/.obs/chartfile/operator/templates/validate-install-crd.yaml
@@ -8,6 +8,7 @@
     "elemental.cattle.io/v1beta1/ManagedOSVersionChannel" "managedosversionchannels"
     "elemental.cattle.io/v1beta1/ManagedOSVersion" "managedosversions"
     "elemental.cattle.io/v1beta1/SeedImage" "seedimages"
+    "elemental.cattle.io/v1beta1/Metadata" "metadatas"
   }}
   {{- range $api, $crd := $apis -}}
     {{- if not ($.Capabilities.APIVersions.Has $api) -}}

--- a/.obs/chartfile/operator/templates/validate-install-crd.yaml
+++ b/.obs/chartfile/operator/templates/validate-install-crd.yaml
@@ -8,7 +8,7 @@
     "elemental.cattle.io/v1beta1/ManagedOSVersionChannel" "managedosversionchannels"
     "elemental.cattle.io/v1beta1/ManagedOSVersion" "managedosversions"
     "elemental.cattle.io/v1beta1/SeedImage" "seedimages"
-    "elemental.cattle.io/v1beta1/Metadata" "metadatas"
+    "elemental.cattle.io/v1beta1/Metadata" "metadata"
   }}
   {{- range $api, $crd := $apis -}}
     {{- if not ($.Capabilities.APIVersions.Has $api) -}}


### PR DESCRIPTION
With #775 reinstalling elemental-operator with helm results in a broken installation. This change is to prevent reinstalling CRDs if there are still instances pending to be deleted.

This will prevent from having silently broken installations. This is the same issue as in #515