### PR TITLE
Check crds chart is aligned with the main operator chart version

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -2,10 +2,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: machineinventories.elemental.cattle.io
 spec:
@@ -198,10 +202,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: machineinventoryselectors.elemental.cattle.io
 spec:
@@ -405,10 +413,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: machineinventoryselectortemplates.elemental.cattle.io
 spec:
@@ -640,10 +652,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: machineregistrations.elemental.cattle.io
 spec:
@@ -964,10 +980,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: managedosimages.elemental.cattle.io
 spec:
@@ -2502,10 +2522,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: managedosversionchannels.elemental.cattle.io
 spec:
@@ -2998,10 +3022,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: managedosversions.elemental.cattle.io
 spec:
@@ -3404,10 +3432,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: metadata.elemental.cattle.io
 spec:
@@ -3461,10 +3493,14 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/part-of: Elemental Operator
+    app.kubernetes.io/version: '{{ .Chart.Version }}'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-elemental
     cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
     release-name: '{{ .Release.Name }}'
   name: seedimages.elemental.cattle.io
 spec:

--- a/.obs/chartfile/operator/templates/validate-install-crd.yaml
+++ b/.obs/chartfile/operator/templates/validate-install-crd.yaml
@@ -22,5 +22,9 @@
     {{- if eq $crdrelease $.Release.Name -}}
       {{- required "Elemental CRDs should be moved to the new elemental-operator-crds chart before upgrading this operator." "" -}}
     {{- end -}}
+    {{- $crdversion := index $crdobj.metadata.annotations "app.kubernetes.io/version" -}}
+    {{- if or (not $crdversion) (ne $crdversion $.Chart.Version) -}}
+      {{- required "Elemental Operator CRDs chart version must match the version of this chart. Please install the corresponding CRD chart before." "" -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,3 +17,9 @@ commonLabels:
   release-name: '{{ .Release.Name }}'
   cluster.x-k8s.io/provider: infrastructure-elemental
   cluster.x-k8s.io/v1beta1: v1beta1
+  helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version }}'
+
+commonAnnotations:
+  app.kubernetes.io/instance: '{{ .Release.Name }}'
+  app.kubernetes.io/version: '{{ .Chart.Version }}'
+  app.kubernetes.io/part-of: 'Elemental Operator' 


### PR DESCRIPTION
Added some annotations and labels for the CRDs chart based on https://v2.helm.sh/docs/chart_best_practices/#standard-labels 

With them we can add a validation to check CRDs chart and Elemental-Operator chart are aligned with the same version.