### PR TITLE
Workaround []byte equality check

### DIFF
--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -670,9 +670,9 @@ var _ = Describe("handle unmanaged finalizer", func() {
 
 		// Check plan secret was updated
 		Expect(planSecret.Annotations[elementalv1.PlanTypeAnnotation]).To(Equal(elementalv1.PlanTypeReset))
-		Expect(planSecret.Data["plan"]).To(Equal(wantPlan))
-		Expect(planSecret.Data["applied-checksum"]).To(Equal([]byte("")))
-		Expect(planSecret.Data["failed-checksum"]).To(Equal([]byte("")))
+		Expect(string(planSecret.Data["plan"])).To(Equal(string(wantPlan)))
+		Expect(string(planSecret.Data["applied-checksum"])).To(Equal(""))
+		Expect(string(planSecret.Data["failed-checksum"])).To(Equal(""))
 
 		// Check we are holding on the MachineInventory (preventing actual deletion)
 		_, err = r.Reconcile(ctx, reconcile.Request{


### PR DESCRIPTION
In GHA we sporadically see equaity check to fail because the underlaying slice arrays of a []byte pair are having a different capacity despite having the same lenght and content.

Failed run example https://github.com/rancher/elemental-operator/actions/runs/9694789636/attempts/1