### PR TITLE
Implement Enabled field on ManagedOSVersionChannels

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -2570,6 +2570,9 @@ spec:
                   DeleteNoLongerInSyncVersions automatically deletes
                   all no-longer-in-sync ManagedOSVersions that were created by this channel.
                 type: boolean
+              enabled:
+                default: true
+                type: boolean
               options:
                 x-kubernetes-preserve-unknown-fields: true
               syncInterval:

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -1,22 +1,30 @@
 questions:
-- variable: defaultChannels.includes.sle_micro_5_5
+- variable: defaultChannels.included
   default: true
-  description: "Default channel that can be used for any generic workload."
-  type: bool
-  label: SLE Micro 5.5 Channel
+  description: "Provide default Elemental OS Channels. Note for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap)"
+  label: Elemental Default OS Channels
+  type: boolean
+  show_subquestion_if: true
   group: "Default Elemental OS Channels"
-- variable: defaultChannels.includes.sle_micro_5_5_kvm
-  default: true
-  description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
-  type: bool
-  label: SLE Micro 5.5 KVM Channel
-  group: "Default Elemental OS Channels"
-- variable: defaultChannels.includes.sle_micro_5_5_rt
-  default: true
-  description: "Channel that can be used for any generic workload with a Real-Time kernel."
-  type: bool
-  label: SLE Micro 5.5 RT Channel
-  group: "Default Elemental OS Channels"
+  subquestions:
+  - variable: defaultChannels.includes.sle_micro_5_5
+    default: true
+    description: "Default channel that can be used for any generic workload."
+    type: boolean
+    label: SLE Micro 5.5 Channel
+    group: "Default Elemental OS Channels"
+  - variable: defaultChannels.includes.sle_micro_5_5_kvm
+    default: true
+    description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
+    type: boolean
+    label: SLE Micro 5.5 KVM Channel
+    group: "Default Elemental OS Channels"
+  - variable: defaultChannels.includes.sle_micro_5_5_rt
+    default: true
+    description: "Channel that can be used for any generic workload with a Real-Time kernel."
+    type: boolean
+    label: SLE Micro 5.5 RT Channel
+    group: "Default Elemental OS Channels"
 - variable: channel.defaultChannel
   default: "false"
   description: "Provide a Custom OS Channel container image"
@@ -26,7 +34,7 @@ questions:
   group: "Custom OS Channel"
   subquestions:
   - variable: channel.image
-    description: "Specify the custom OS channel: for air-gapped scenarios please see https://elemental.docs.rancher.com/airgap for detailed instructions"
+    description: "Specify the custom OS channel: for air-gapped scenarios please see https://elemental.docs.rancher.com/airgap"
     type: string
     label: Custom OS Channel Image
     group: "Custom OS Channel"

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -4,26 +4,26 @@ questions:
   description: "Default channel that can be used for any generic workload."
   type: bool
   label: SLE Micro 5.5 Channel
-  group: "01. Default Elemental OS Channels"
+  group: "Default Elemental OS Channels"
 - variable: defaultChannels.includes.sle_micro_5_5_kvm
   default: true
   description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
   type: bool
   label: SLE Micro 5.5 KVM Channel
-  group: "01. Default Elemental OS Channels"
+  group: "Default Elemental OS Channels"
 - variable: defaultChannels.includes.sle_micro_5_5_rt
   default: true
   description: "Channel that can be used for any generic workload with a Real-Time kernel."
   type: bool
   label: SLE Micro 5.5 RT Channel
-  group: "01. Default Elemental OS Channels"
+  group: "Default Elemental OS Channels"
 - variable: channel.defaultChannel
   default: "false"
   description: "Provide a Custom OS Channel container image"
   label: Custom OS Channel
   type: boolean
   show_subquestion_if: true
-  group: "02. Custom OS Channel"
+  group: "Custom OS Channel"
   subquestions:
   - variable: channel.image
     description: "Specify the custom OS channel: for air-gapped scenarios please see https://elemental.docs.rancher.com/airgap for detailed instructions"
@@ -40,4 +40,4 @@ questions:
   description: "Enable debug logging in the Elemental operator"
   type: boolean
   label: "Enable Debug Logging"
-  group: "03. Logging"
+  group: "Logging"

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -7,19 +7,19 @@ questions:
   show_subquestion_if: true
   group: "Default Elemental OS Channels"
   subquestions:
-  - variable: defaultChannels.includes.sle_micro_5_5
+  - variable: defaultChannels.includes.sleMicro55
     default: true
     description: "Default channel that can be used for any generic workload."
     type: boolean
     label: SLE Micro 5.5 Channel
     group: "Default Elemental OS Channels"
-  - variable: defaultChannels.includes.sle_micro_5_5_kvm
+  - variable: defaultChannels.includes.sleMicro55KVM
     default: true
     description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
     type: boolean
     label: SLE Micro 5.5 KVM Channel
     group: "Default Elemental OS Channels"
-  - variable: defaultChannels.includes.sle_micro_5_5_rt
+  - variable: defaultChannels.includes.sleMicro55RT
     default: true
     description: "Channel that can be used for any generic workload with a Real-Time kernel."
     type: boolean

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -1,6 +1,6 @@
 questions:
 - variable: channel.defaultChannel
-  default: "true"
+  default: "false"
   description: "Provide an Elemental OS Channel container image"
   label: Elemental OS Channel
   type: boolean
@@ -8,17 +8,41 @@ questions:
   group: "Elemental OS Channel"
   subquestions:
   - variable: channel.image
-    default: "%%IMG_REPO%%/rancher/elemental-channel"
     description: "Specify the Elemental OS channel: for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap for detailed instructions)"
     type: string
     label: Elemental OS Channel Image
     group: "Elemental OS Channel"
   - variable: channel.tag
-    default: "%VERSION%"
     description: "Specify Elemental OS channel image tag"
     type: string
     label: "Elemental OS Channel Tag"
     group: "Elemental OS Channel"
+- variable: defaultChannels.included
+  default: true
+  description: "Provide default Elemental OS Channels. Note for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap )"
+  label: Elemental OS Channels
+  type: boolean
+  show_subquestion_if: true
+  group: "Elemental OS Channels"
+  subquestions:
+  - variable: defaultChannels.includes.sle_micro_5_5
+    default: true
+    description: "Default channel that can be used for any generic workload."
+    type: bool
+    label: SLE Micro 5.5 Channel
+    group: "Elemental OS Channels"
+  - variable: defaultChannels.includes.sle_micro_5_5_kvm
+    default: true
+    description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
+    type: bool
+    label: SLE Micro 5.5 KVM Channel
+    group: "Elemental OS Channels"
+  - variable: defaultChannels.includes.sle_micro_5_5_rt
+    default: true
+    description: "Channel that can be used for any generic workload with a Real-Time kernel."
+    type: bool
+    label: SLE Micro 5.5 RT Channel
+    group: "Elemental OS Channels"
 - variable: debug
   default: "false"
   description: "Enable debug logging in the Elemental operator"

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -1,51 +1,43 @@
 questions:
+- variable: defaultChannels.includes.sle_micro_5_5
+  default: true
+  description: "Default channel that can be used for any generic workload."
+  type: bool
+  label: SLE Micro 5.5 Channel
+  group: "01. Default Elemental OS Channels"
+- variable: defaultChannels.includes.sle_micro_5_5_kvm
+  default: true
+  description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
+  type: bool
+  label: SLE Micro 5.5 KVM Channel
+  group: "01. Default Elemental OS Channels"
+- variable: defaultChannels.includes.sle_micro_5_5_rt
+  default: true
+  description: "Channel that can be used for any generic workload with a Real-Time kernel."
+  type: bool
+  label: SLE Micro 5.5 RT Channel
+  group: "01. Default Elemental OS Channels"
 - variable: channel.defaultChannel
   default: "false"
-  description: "Provide an Elemental OS Channel container image"
-  label: Elemental OS Channel
+  description: "Provide a Custom OS Channel container image"
+  label: Custom OS Channel
   type: boolean
   show_subquestion_if: true
-  group: "Elemental OS Channel"
+  group: "02. Custom OS Channel"
   subquestions:
   - variable: channel.image
-    description: "Specify the Elemental OS channel: for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap for detailed instructions)"
+    description: "Specify the custom OS channel: for air-gapped scenarios please see https://elemental.docs.rancher.com/airgap for detailed instructions"
     type: string
-    label: Elemental OS Channel Image
-    group: "Elemental OS Channel"
+    label: Custom OS Channel Image
+    group: "Custom OS Channel"
   - variable: channel.tag
-    description: "Specify Elemental OS channel image tag"
+    description: "Specify Custom OS Channel image tag"
     type: string
-    label: "Elemental OS Channel Tag"
-    group: "Elemental OS Channel"
-- variable: defaultChannels.included
-  default: true
-  description: "Provide default Elemental OS Channels. Note for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap )"
-  label: Elemental OS Channels
-  type: boolean
-  show_subquestion_if: true
-  group: "Elemental OS Channels"
-  subquestions:
-  - variable: defaultChannels.includes.sle_micro_5_5
-    default: true
-    description: "Default channel that can be used for any generic workload."
-    type: bool
-    label: SLE Micro 5.5 Channel
-    group: "Elemental OS Channels"
-  - variable: defaultChannels.includes.sle_micro_5_5_kvm
-    default: true
-    description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
-    type: bool
-    label: SLE Micro 5.5 KVM Channel
-    group: "Elemental OS Channels"
-  - variable: defaultChannels.includes.sle_micro_5_5_rt
-    default: true
-    description: "Channel that can be used for any generic workload with a Real-Time kernel."
-    type: bool
-    label: SLE Micro 5.5 RT Channel
-    group: "Elemental OS Channels"
+    label: "Custom OS Channel Tag"
+    group: "Custom OS Channel"
 - variable: debug
   default: "false"
   description: "Enable debug logging in the Elemental operator"
   type: boolean
   label: "Enable Debug Logging"
-  group: "Logging"
+  group: "03. Logging"

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -1,30 +1,25 @@
 questions:
-- variable: defaultChannels.included
+- variable: defaultChannels.sleMicro55.included
+  show_if: "defaultChannels.sleMicro55"
   default: true
-  description: "Provide default Elemental OS Channels. Note for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap)"
-  label: Elemental Default OS Channels
+  description: "Default channel that can be used for any generic workload."
   type: boolean
-  show_subquestion_if: true
+  label: SLE Micro 5.5 Channel
   group: "Default Elemental OS Channels"
-  subquestions:
-  - variable: defaultChannels.includes.sleMicro55
-    default: true
-    description: "Default channel that can be used for any generic workload."
-    type: boolean
-    label: SLE Micro 5.5 Channel
-    group: "Default Elemental OS Channels"
-  - variable: defaultChannels.includes.sleMicro55KVM
-    default: true
-    description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
-    type: boolean
-    label: SLE Micro 5.5 KVM Channel
-    group: "Default Elemental OS Channels"
-  - variable: defaultChannels.includes.sleMicro55RT
-    default: true
-    description: "Channel that can be used for any generic workload with a Real-Time kernel."
-    type: boolean
-    label: SLE Micro 5.5 RT Channel
-    group: "Default Elemental OS Channels"
+- variable: defaultChannels.sleMicro55KVM.included
+  show_if: "defaultChannels.sleMicro55KVM"
+  default: true
+  description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
+  type: boolean
+  label: SLE Micro 5.5 KVM Channel
+  group: "Default Elemental OS Channels"
+- variable: defaultChannels.sleMicro55RT.included
+  show_if: "defaultChannels.sleMicro55RT"
+  default: true
+  description: "Channel that can be used for any generic workload with a Real-Time kernel."
+  type: boolean
+  label: SLE Micro 5.5 RT Channel
+  group: "Default Elemental OS Channels"
 - variable: channel.defaultChannel
   default: "false"
   description: "Provide a Custom OS Channel container image"

--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -4,21 +4,21 @@ questions:
   default: true
   description: "Default channel that can be used for any generic workload."
   type: boolean
-  label: SLE Micro 5.5 Channel
+  label: SLE Micro 5.5
   group: "Default Elemental OS Channels"
 - variable: defaultChannels.sleMicro55KVM.included
   show_if: "defaultChannels.sleMicro55KVM"
   default: true
   description: "Ready to be used with KVM. Contains QEMU Guest agent by default."
   type: boolean
-  label: SLE Micro 5.5 KVM Channel
+  label: SLE Micro 5.5 KVM
   group: "Default Elemental OS Channels"
 - variable: defaultChannels.sleMicro55RT.included
   show_if: "defaultChannels.sleMicro55RT"
   default: true
   description: "Channel that can be used for any generic workload with a Real-Time kernel."
   type: boolean
-  label: SLE Micro 5.5 RT Channel
+  label: SLE Micro 5.5 RT
   group: "Default Elemental OS Channels"
 - variable: channel.defaultChannel
   default: "false"

--- a/.obs/chartfile/operator/templates/channels.yaml
+++ b/.obs/chartfile/operator/templates/channels.yaml
@@ -12,7 +12,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.includes.sle_micro_5_5 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -26,7 +26,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.includes.sle_micro_5_5_kvm (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_kvm (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -40,7 +40,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.includes.sle_micro_5_5_rt (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_rt (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:

--- a/.obs/chartfile/operator/templates/channels.yaml
+++ b/.obs/chartfile/operator/templates/channels.yaml
@@ -12,7 +12,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
+{{ if and .Values.defaultChannels.includes.sle_micro_5_5 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -26,7 +26,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_kvm (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
+{{ if and .Values.defaultChannels.includes.sle_micro_5_5_kvm (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -40,7 +40,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_rt (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
+{{ if and .Values.defaultChannels.includes.sle_micro_5_5_rt (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:

--- a/.obs/chartfile/operator/templates/channels.yaml
+++ b/.obs/chartfile/operator/templates/channels.yaml
@@ -12,7 +12,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sleMicro55 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -26,7 +26,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_kvm (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sleMicro55KVM (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
@@ -40,7 +40,7 @@ spec:
   type: custom
 {{ end }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_rt (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sleMicro55RT (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:

--- a/.obs/chartfile/operator/templates/channels.yaml
+++ b/.obs/chartfile/operator/templates/channels.yaml
@@ -11,48 +11,25 @@ spec:
     image: {{ .Values.channel.image }}:{{ .Values.channel.tag }}
   type: custom
 {{ end }}
+
+{{ range $key, $channel := .Values.defaultChannels }}
+  {{ if and $channel.included (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "$channel.name")) }}
 ---
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sleMicro55 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
 apiVersion: elemental.cattle.io/v1beta1
 kind: ManagedOSVersionChannel
 metadata:
-  name: sle-micro-5.5
+  name: {{ $channel.name }}
   namespace: fleet-default
 spec:
-  deleteNoLongerInSyncVersions: true
-  enabled: false
+  deleteNoLongerInSyncVersions: {{ $channel.deleteNoLongerInSyncVersions }}
+  enabled: {{ $channel.enabled }}
   options:
-    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5
+    image: {{ $channel.image }}
   type: custom
+  {{ end }}
 {{ end }}
----
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sleMicro55KVM (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
-apiVersion: elemental.cattle.io/v1beta1
-kind: ManagedOSVersionChannel
-metadata:
-  name: sle-micro-5.5-kvm
-  namespace: fleet-default
-spec:
-  deleteNoLongerInSyncVersions: true
-  enabled: false
-  options:
-    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5-kvm
-  type: custom
-{{ end }}
----
-{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sleMicro55RT (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
-apiVersion: elemental.cattle.io/v1beta1
-kind: ManagedOSVersionChannel
-metadata:
-  name: sle-micro-5.5-rt
-  namespace: fleet-default
-spec:
-  deleteNoLongerInSyncVersions: true
-  enabled: false
-  options:
-    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5-rt
-  type: custom
-{{ end }}
+
+
 # Keep pre-existing channels managed by Helm if they do not match with the current default
 # this way if an upgrade introduces a new channel any pre-existing channel managed by Helm is not deleted
 {{ range $index, $channel := (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "").items }}

--- a/.obs/chartfile/operator/templates/channels.yaml
+++ b/.obs/chartfile/operator/templates/channels.yaml
@@ -11,7 +11,48 @@ spec:
     image: {{ .Values.channel.image }}:{{ .Values.channel.tag }}
   type: custom
 {{ end }}
-
+---
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5 (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5")) }}
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: sle-micro-5.5
+  namespace: fleet-default
+spec:
+  deleteNoLongerInSyncVersions: true
+  enabled: false
+  options:
+    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5
+  type: custom
+{{ end }}
+---
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_kvm (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-kvm")) }}
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: sle-micro-5.5-kvm
+  namespace: fleet-default
+spec:
+  deleteNoLongerInSyncVersions: true
+  enabled: false
+  options:
+    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5-kvm
+  type: custom
+{{ end }}
+---
+{{ if and .Values.defaultChannels.included .Values.defaultChannels.includes.sle_micro_5_5_rt (not (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "sle-micro-5.5-rt")) }}
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: sle-micro-5.5-rt
+  namespace: fleet-default
+spec:
+  deleteNoLongerInSyncVersions: true
+  enabled: false
+  options:
+    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5-rt
+  type: custom
+{{ end }}
 # Keep pre-existing channels managed by Helm if they do not match with the current default
 # this way if an upgrade introduces a new channel any pre-existing channel managed by Helm is not deleted
 {{ range $index, $channel := (lookup "elemental.cattle.io/v1beta1" "ManagedOSVersionChannel" "fleet-default" "").items }}
@@ -23,8 +64,6 @@ metadata:
   name: {{ $channel.metadata.name }}
   namespace: fleet-default
 spec:
-  options:
-    image: {{ $channel.spec.options.image }}
-  type: custom
+    {{- toYaml $channel.spec | nindent 2}}
   {{ end }}
 {{ end }}

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -11,6 +11,8 @@ seedImage:
 
 # default Elemental channels
 defaultChannels:
+  # default channels are included in the chart
+  included: true
   # default channels to include
   includes:
     sle_micro_5_5: true

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -9,10 +9,15 @@ seedImage:
   tag: "%VERSION%"
   imagePullPolicy: IfNotPresent
 
-channel:
-  name: "sle-micro-5.5"
-  image: "%%IMG_REPO%%/rancher/elemental-channel/sle-micro"
-  tag: "5.5"
+# default Elemental channels
+defaultChannels:
+  # default channels are included in the chart
+  included: true
+  # default channels to include
+  includes:
+    sle_micro_5_5: true
+    sle_micro_5_5_kvm: true
+    sle_micro_5_5_rt: true
 
 # number of operator replicas to deploy
 replicas: 1

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -11,8 +11,6 @@ seedImage:
 
 # default Elemental channels
 defaultChannels:
-  # default channels are included in the chart
-  included: true
   # default channels to include
   includes:
     sle_micro_5_5: true

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -21,9 +21,9 @@ defaultChannels:
   included: true
   # default channels to include
   includes:
-    sle_micro_5_5: true
-    sle_micro_5_5_kvm: true
-    sle_micro_5_5_rt: true
+    sleMicro55: true
+    sleMicro55KVM: true
+    sleMicro55RT: true
 
 # number of operator replicas to deploy
 replicas: 1

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -9,6 +9,12 @@ seedImage:
   tag: "%VERSION%"
   imagePullPolicy: IfNotPresent
 
+# a custom channel to install
+#channel:
+#  name: "my-os-channel"
+#  image: "my-repo/my-os-channel"
+#  tag: "1.2.3"
+
 # default Elemental channels
 defaultChannels:
   # default channels are included in the chart

--- a/.obs/chartfile/operator/values.yaml
+++ b/.obs/chartfile/operator/values.yaml
@@ -17,13 +17,24 @@ seedImage:
 
 # default Elemental channels
 defaultChannels:
-  # default channels are included in the chart
-  included: true
-  # default channels to include
-  includes:
-    sleMicro55: true
-    sleMicro55KVM: true
-    sleMicro55RT: true
+  sleMicro55:
+    included: true 
+    name: sle-micro-5.5
+    enabled: false
+    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5
+    deleteNoLongerInSyncVersions: true
+  sleMicro55KVM:
+    included: true
+    name: sle-micro-5.5-kvm
+    enabled: false
+    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5-kvm
+    deleteNoLongerInSyncVersions: true
+  sleMicro55RT:
+    included: true
+    name: sle-micro-5.5-rt
+    enabled: false
+    image: registry.opensuse.org/isv/rancher/elemental/dev/containers/rancher/elemental-channel/sle-micro:5.5-rt
+    deleteNoLongerInSyncVersions: true
 
 # number of operator replicas to deploy
 replicas: 1

--- a/Makefile
+++ b/Makefile
@@ -193,13 +193,14 @@ setup-full-cluster: build-docker-operator build-docker-seedimage-builder chart s
 	kind load docker-image --name $(CLUSTER_NAME) ${REGISTRY_HEADER}${REPO_SEEDIMAGE}:${TAG_SEEDIMAGE} && \
 	cd $(ROOT_DIR)/tests && $(GINKGO) -r -v --label-filter="do-nothing" ./e2e
 
-# This builds the docker image, generates the chart, loads the image into the kind cluster and upgrades the chart to latest
+# This generates the chart, builds the docker image, loads the image into the kind cluster and upgrades the chart to latest
 # useful to test changes into the operator with a running system, without clearing the operator namespace
 # thus losing any registration/inventories/os CRDs already created
-reload-operator: build-docker-operator chart
+reload-operator: chart build-docker-operator
 	kind load docker-image --name $(CLUSTER_NAME) ${REGISTRY_HEADER}${REPO}:${CHART_VERSION}
 	helm upgrade -n cattle-elemental-system elemental-operator-crds $(CHART_CRDS)
 	helm upgrade -n cattle-elemental-system elemental-operator $(CHART)
+	kubectl -n cattle-elemental-system rollout restart deployment/elemental-operator
 
 .PHONY: vendor
 vendor:

--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -113,6 +113,9 @@ const (
 
 	// FailedToCreatePodReason documents that managed OS version channel failed to create the synchronization pod
 	FailedToCreatePodReason = "FailedToCreatePod"
+
+	// ChannelDisabledReason documents that the managed OS version channel is not enabled
+	ChannelDisabledReason = "ChannelDisabled"
 )
 
 // Managed OS Image conditions

--- a/api/v1beta1/managedosversionchannel_types.go
+++ b/api/v1beta1/managedosversionchannel_types.go
@@ -44,6 +44,9 @@ type ManagedOSVersionChannelSpec struct {
 	// +optional
 	// +kubebuilder:default:=false
 	DeleteNoLongerInSyncVersions bool `json:"deleteNoLongerInSyncVersions,omitempty"`
+	// +optional
+	// +kubebuilder:default:=true
+	Enabled bool `json:"enabled"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +optional

--- a/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
@@ -43,6 +43,9 @@ spec:
                   DeleteNoLongerInSyncVersions automatically deletes
                   all no-longer-in-sync ManagedOSVersions that were created by this channel.
                 type: boolean
+              enabled:
+                default: true
+                type: boolean
               options:
                 x-kubernetes-preserve-unknown-fields: true
               syncInterval:

--- a/tests/catalog/managedosversionchannel.go
+++ b/tests/catalog/managedosversionchannel.go
@@ -34,6 +34,7 @@ func NewManagedOSVersionChannel(namespace, name, sType, interval string, options
 			Namespace: namespace,
 		},
 		Spec: elementalv1.ManagedOSVersionChannelSpec{
+			Enabled:          true,
 			Type:             sType,
 			SyncInterval:     interval,
 			Options:          options,


### PR DESCRIPTION
Closes rancher/elemental#1462

This PR introduces a new `ManagedOSVersionChannel.spec.enabled` flag that can be used to disable a channel.
Channels are always enabled by default, so disabling has to be explicit. 

Disabling channels will also flag all linked ManagedOSVersions as no longer in sync.

Additionally, if `ManagedOSVersionChannel.spec.deleteNoLongerInSyncVersions` is true, all linked ManagedOSVersions will be flagged for deletion.