### PR TITLE
operator: rework label templating

### DIFF
--- a/pkg/hostinfo/hostinfo.go
+++ b/pkg/hostinfo/hostinfo.go
@@ -137,6 +137,13 @@ func host(opts ...*ghw.WithOption) (HostInfo, error) {
 
 // Deprecated. Remove me together with 'MsgSystemData' type.
 func FillData(data []byte) (map[string]interface{}, error) {
+	// Also available but not used:
+	// systemData.Product -> name, vendor, serial,uuid,sku,version. Kind of smbios data
+	// systemData.BIOS -> info about the bios. Useless IMO
+	// systemData.Baseboard -> asset, serial, vendor,version,product. Kind of useless?
+	// systemData.Chassis -> asset, serial, vendor,version,product, type. Maybe be useful depending on the provider.
+	// systemData.Topology -> CPU/memory and cache topology. No idea if useful.
+
 	systemData := &HostInfo{}
 	if err := json.Unmarshal(data, &systemData); err != nil {
 		return nil, fmt.Errorf("unmarshalling system data payload: %w", err)

--- a/pkg/register/websocket.go
+++ b/pkg/register/websocket.go
@@ -35,7 +35,7 @@ const (
 	MsgLabels
 	MsgGet                            // v0.5.0
 	MsgVersion                        // v1.1.0
-	MsgSystemData                     // v1.1.1
+	MsgSystemData                     // v1.1.1	deprecated by MsgSystemDataV2
 	MsgConfig                         // v1.1.1
 	MsgError                          // v1.1.1
 	MsgAnnotations                    // v1.1.4

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -249,11 +249,8 @@ func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elementalv1
 		case register.MsgGet:
 			// Final call: here we commit the MachineInventory, send the Elemental config data
 			// and close the connection.
-			if err := updateInventoryName(tmpl, inventory); err != nil {
-				return fmt.Errorf("failed to resolve inventory name: %w", err)
-			}
-			if err := updateInventoryLabels(tmpl, inventory, registration); err != nil {
-				return fmt.Errorf("failed to update inventory labels: %w", err)
+			if err := updateInventoryWithTemplates(tmpl, inventory, registration); err != nil {
+				return err
 			}
 			return i.handleGet(conn, protoVersion, inventory, registration)
 		case register.MsgUpdate:

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"path"
-	"regexp"
 
 	"github.com/gorilla/websocket"
 	"gopkg.in/yaml.v3"
@@ -42,13 +41,7 @@ type LegacyConfig struct {
 	CloudConfig map[string]interface{} `yaml:"cloud-config,omitempty"`
 }
 
-var (
-	sanitize             = regexp.MustCompile("[^0-9a-zA-Z_]")
-	sanitizeHostname     = regexp.MustCompile("[^0-9a-zA-Z.]")
-	doubleDash           = regexp.MustCompile("--+")
-	start                = regexp.MustCompile("^[a-zA-Z0-9]")
-	errInventoryNotFound = errors.New("MachineInventory not found")
-)
+var errInventoryNotFound = errors.New("MachineInventory not found")
 
 func (i *InventoryServer) apiRegistration(resp http.ResponseWriter, req *http.Request) error {
 	var err error

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -24,16 +24,13 @@ import (
 	"net/http"
 	"path"
 	"regexp"
-	"strings"
 
 	"github.com/gorilla/websocket"
-	values "github.com/rancher/wrangler/v2/pkg/data"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
-	"github.com/rancher/elemental-operator/pkg/hostinfo"
 	"github.com/rancher/elemental-operator/pkg/log"
 	"github.com/rancher/elemental-operator/pkg/register"
 )
@@ -217,34 +214,6 @@ func (i *InventoryServer) getRancherCACert() string {
 	return cacert
 }
 
-func replaceStringData(data map[string]interface{}, name string) (string, error) {
-	str := name
-	result := &strings.Builder{}
-	for {
-		i := strings.Index(str, "${")
-		if i == -1 {
-			result.WriteString(str)
-			break
-		}
-		j := strings.Index(str[i:], "}")
-		if j == -1 {
-			result.WriteString(str)
-			break
-		}
-
-		result.WriteString(str[:i])
-		obj := values.GetValueN(data, strings.Split(str[i+2:j+i], "/")...)
-		if str, ok := obj.(string); ok {
-			result.WriteString(str)
-		} else {
-			return "", errValueNotFound
-		}
-		str = str[j+i+1:]
-	}
-
-	return result.String(), nil
-}
-
 func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elementalv1.MachineInventory, registration *elementalv1.MachineRegistration) error {
 	protoVersion := register.MsgUndefined
 
@@ -379,137 +348,6 @@ func decodeProtocolVersion(data []byte) (register.MessageType, error) {
 	}
 
 	return protoVersion, nil
-}
-
-func updateInventoryWithAnnotations(data []byte, mInventory *elementalv1.MachineInventory) error {
-	annotations := map[string]string{}
-	if err := json.Unmarshal(data, &annotations); err != nil {
-		return err
-	}
-	log.Debug("Adding annotations from client data")
-	if mInventory.Annotations == nil {
-		mInventory.Annotations = map[string]string{}
-	}
-	for key, val := range annotations {
-		mInventory.Annotations[fmt.Sprintf("elemental.cattle.io/%s", sanitizeUserInput(key))] = sanitizeUserInput(val)
-	}
-	return nil
-}
-
-// updateInventoryFromSMBIOSData() updates mInventory Name and Labels from the MachineRegistration and the SMBIOS data
-func updateInventoryFromSMBIOSData(data []byte, mInventory *elementalv1.MachineInventory, mRegistration *elementalv1.MachineRegistration) error {
-	smbiosData := map[string]interface{}{}
-	if err := json.Unmarshal(data, &smbiosData); err != nil {
-		return err
-	}
-	// Sanitize any lower dashes into dashes as hostnames cannot have lower dashes, and we use the inventory name
-	// to set the machine hostname. Also set it to lowercase
-	name, err := replaceStringData(smbiosData, mInventory.Name)
-	if err == nil {
-		name = sanitizeStringHostname(name)
-		mInventory.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
-	} else {
-		if errors.Is(err, errValueNotFound) {
-			// value not found, will be set in updateInventoryFromSystemData
-			log.Warningf("SMBIOS Value not found: %v", mInventory.Name)
-		} else {
-			return err
-		}
-	}
-
-	log.Debugf("Adding labels from registration")
-	// Add extra label info from data coming from smbios and based on the registration data
-	if mInventory.Labels == nil {
-		mInventory.Labels = map[string]string{}
-	}
-	for k, v := range mRegistration.Spec.MachineInventoryLabels {
-		parsedData, err := replaceStringData(smbiosData, v)
-		if err != nil {
-			if errors.Is(err, errValueNotFound) {
-				log.Debugf("Value not found: %v", v)
-				continue
-			}
-			log.Errorf("Failed parsing smbios data: %v", err.Error())
-			return err
-		}
-		parsedData = sanitizeString(parsedData)
-
-		log.Debugf("Parsed %s into %s with smbios data, setting it to label %s", v, parsedData, k)
-		mInventory.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(parsedData, "-"), "-")
-	}
-	return nil
-}
-
-// updateInventoryFromSystemDataNG receives digested hardware labels from the client
-func updateInventoryFromSystemDataNG(data []byte, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
-	labels := map[string]interface{}{}
-
-	if err := json.Unmarshal(data, &labels); err != nil {
-		return fmt.Errorf("unmarshalling system data labels payload: %w", err)
-	}
-
-	return sanitizeSystemDataLabels(labels, inv, reg)
-}
-
-// Deprecated. Remove me together with 'MsgSystemData' type.
-// updateInventoryFromSystemData creates labels in the inventory based on the hardware information
-func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
-	log.Infof("Adding labels from system data")
-
-	labels, err := hostinfo.FillData(data)
-	if err != nil {
-		return err
-	}
-
-	return sanitizeSystemDataLabels(labels, inv, reg)
-}
-
-func sanitizeSystemDataLabels(labels map[string]interface{}, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
-	// Also available but not used:
-	// systemData.Product -> name, vendor, serial,uuid,sku,version. Kind of smbios data
-	// systemData.BIOS -> info about the bios. Useless IMO
-	// systemData.Baseboard -> asset, serial, vendor,version,product. Kind of useless?
-	// systemData.Chassis -> asset, serial, vendor,version,product, type. Maybe be useful depending on the provider.
-	// systemData.Topology -> CPU/memory and cache topology. No idea if useful.
-
-	name, err := replaceStringData(labels, inv.Name)
-	if err != nil {
-		if errors.Is(err, errValueNotFound) {
-			log.Warningf("System data value not found: %v", inv.Name)
-			name = "m"
-		} else {
-			return err
-		}
-	}
-	name = sanitizeStringHostname(name)
-
-	inv.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
-
-	log.Debugf("Parsing labels from System Data")
-
-	if inv.Labels == nil {
-		inv.Labels = map[string]string{}
-	}
-
-	for k, v := range reg.Spec.MachineInventoryLabels {
-		log.Debugf("Parsing: %v : %v", k, v)
-
-		parsedData, err := replaceStringData(labels, v)
-		if err != nil {
-			if errors.Is(err, errValueNotFound) {
-				log.Debugf("Value not found: %v", v)
-				continue
-			}
-			log.Errorf("Failed parsing system data: %v", err.Error())
-			return err
-		}
-		parsedData = sanitizeString(parsedData)
-
-		log.Debugf("Parsed %s into %s with system data, setting it to label %s", v, parsedData, k)
-		inv.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(parsedData, "-"), "-")
-	}
-
-	return nil
 }
 
 // sanitizeString will sanitize a given string by:

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -238,11 +238,11 @@ func (i *InventoryServer) serveLoop(conn *websocket.Conn, inventory *elementalv1
 			}
 			tmpl.Fill(smbiosData)
 		case register.MsgLabels:
-			if err := updateInventoryWithLabels(inventory, data); err != nil {
+			if err := mergeInventoryLabels(inventory, data); err != nil {
 				return err
 			}
 		case register.MsgAnnotations:
-			err = updateInventoryWithAnnotations(data, inventory)
+			err = mergeInventoryAnnotations(data, inventory)
 			if err != nil {
 				return fmt.Errorf("failed to decode dynamic data: %w", err)
 			}

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -207,7 +207,7 @@ func TestBuildName(t *testing.T) {
 		},
 		{
 			Format: "${level1B",
-			Output: "m-level1B",
+			Output: "level1B",
 		},
 		{
 			Format: "a${level1B",
@@ -219,11 +219,11 @@ func TestBuildName(t *testing.T) {
 		},
 		{
 			Format: "${",
-			Output: "m-",
+			Output: "",
 		},
 		{
 			Format: "a${",
-			Output: "a-",
+			Output: "a",
 		},
 		{
 			Format: "${level1A}",
@@ -265,7 +265,7 @@ func TestBuildName(t *testing.T) {
 		t.Run(testCase.Format, func(t *testing.T) {
 			str, err := tmpl.Decode(testCase.Format)
 			if testCase.Error == "" {
-				str = sanitizeString(str)
+				str = sanitizeLabel(str)
 				assert.NilError(t, err)
 				assert.Equal(t, testCase.Output, str, "'%s' not equal to '%s'", testCase.Output, str)
 			} else {

--- a/pkg/server/labeltmpl.go
+++ b/pkg/server/labeltmpl.go
@@ -33,6 +33,16 @@ var (
 	end        = regexp.MustCompile("[a-zA-Z0-9]$")
 )
 
+func updateInventoryWithTemplates(tmpl templater.Templater, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
+	if err := updateInventoryName(tmpl, inv); err != nil {
+		return fmt.Errorf("failed to resolve inventory name: %w", err)
+	}
+	if err := updateInventoryLabels(tmpl, inv, reg); err != nil {
+		return fmt.Errorf("failed to update inventory labels: %w", err)
+	}
+	return nil
+}
+
 func updateInventoryName(tmpl templater.Templater, inv *elementalv1.MachineInventory) error {
 	// Inventory Name should be set only on freshly created inventories.
 	if !isNewInventory(inv) {

--- a/pkg/server/labeltmpl.go
+++ b/pkg/server/labeltmpl.go
@@ -19,11 +19,19 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/log"
 	"github.com/rancher/elemental-operator/pkg/templater"
+)
+
+var (
+	sanitize         = regexp.MustCompile("[^0-9a-zA-Z_]")
+	sanitizeHostname = regexp.MustCompile("[^0-9a-zA-Z.]")
+	doubleDash       = regexp.MustCompile("--+")
+	start            = regexp.MustCompile("^[a-zA-Z0-9]")
 )
 
 func updateInventoryName(tmpl templater.Templater, inv *elementalv1.MachineInventory) error {

--- a/pkg/server/labeltmpl.go
+++ b/pkg/server/labeltmpl.go
@@ -1,0 +1,187 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	"github.com/rancher/elemental-operator/pkg/hostinfo"
+	"github.com/rancher/elemental-operator/pkg/log"
+	values "github.com/rancher/wrangler/v2/pkg/data"
+)
+
+func updateInventoryWithAnnotations(data []byte, mInventory *elementalv1.MachineInventory) error {
+	annotations := map[string]string{}
+	if err := json.Unmarshal(data, &annotations); err != nil {
+		return err
+	}
+	log.Debug("Adding annotations from client data")
+	if mInventory.Annotations == nil {
+		mInventory.Annotations = map[string]string{}
+	}
+	for key, val := range annotations {
+		mInventory.Annotations[fmt.Sprintf("elemental.cattle.io/%s", sanitizeUserInput(key))] = sanitizeUserInput(val)
+	}
+	return nil
+}
+
+// updateInventoryFromSMBIOSData() updates mInventory Name and Labels from the MachineRegistration and the SMBIOS data
+func updateInventoryFromSMBIOSData(data []byte, mInventory *elementalv1.MachineInventory, mRegistration *elementalv1.MachineRegistration) error {
+	smbiosData := map[string]interface{}{}
+	if err := json.Unmarshal(data, &smbiosData); err != nil {
+		return err
+	}
+	// Sanitize any lower dashes into dashes as hostnames cannot have lower dashes, and we use the inventory name
+	// to set the machine hostname. Also set it to lowercase
+	name, err := replaceStringData(smbiosData, mInventory.Name)
+	if err == nil {
+		name = sanitizeStringHostname(name)
+		mInventory.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
+	} else {
+		if errors.Is(err, errValueNotFound) {
+			// value not found, will be set in updateInventoryFromSystemData
+			log.Warningf("SMBIOS Value not found: %v", mInventory.Name)
+		} else {
+			return err
+		}
+	}
+
+	log.Debugf("Adding labels from registration")
+	// Add extra label info from data coming from smbios and based on the registration data
+	if mInventory.Labels == nil {
+		mInventory.Labels = map[string]string{}
+	}
+	for k, v := range mRegistration.Spec.MachineInventoryLabels {
+		parsedData, err := replaceStringData(smbiosData, v)
+		if err != nil {
+			if errors.Is(err, errValueNotFound) {
+				log.Debugf("Value not found: %v", v)
+				continue
+			}
+			log.Errorf("Failed parsing smbios data: %v", err.Error())
+			return err
+		}
+		parsedData = sanitizeString(parsedData)
+
+		log.Debugf("Parsed %s into %s with smbios data, setting it to label %s", v, parsedData, k)
+		mInventory.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(parsedData, "-"), "-")
+	}
+	return nil
+}
+
+// updateInventoryFromSystemDataNG receives digested hardware labels from the client
+func updateInventoryFromSystemDataNG(data []byte, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
+	labels := map[string]interface{}{}
+
+	if err := json.Unmarshal(data, &labels); err != nil {
+		return fmt.Errorf("unmarshalling system data labels payload: %w", err)
+	}
+
+	return sanitizeSystemDataLabels(labels, inv, reg)
+}
+
+// Deprecated. Remove me together with 'MsgSystemData' type.
+// updateInventoryFromSystemData creates labels in the inventory based on the hardware information
+func updateInventoryFromSystemData(data []byte, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
+	log.Infof("Adding labels from system data")
+
+	labels, err := hostinfo.FillData(data)
+	if err != nil {
+		return err
+	}
+
+	return sanitizeSystemDataLabels(labels, inv, reg)
+}
+
+func sanitizeSystemDataLabels(labels map[string]interface{}, inv *elementalv1.MachineInventory, reg *elementalv1.MachineRegistration) error {
+	// Also available but not used:
+	// systemData.Product -> name, vendor, serial,uuid,sku,version. Kind of smbios data
+	// systemData.BIOS -> info about the bios. Useless IMO
+	// systemData.Baseboard -> asset, serial, vendor,version,product. Kind of useless?
+	// systemData.Chassis -> asset, serial, vendor,version,product, type. Maybe be useful depending on the provider.
+	// systemData.Topology -> CPU/memory and cache topology. No idea if useful.
+
+	name, err := replaceStringData(labels, inv.Name)
+	if err != nil {
+		if errors.Is(err, errValueNotFound) {
+			log.Warningf("System data value not found: %v", inv.Name)
+			name = "m"
+		} else {
+			return err
+		}
+	}
+	name = sanitizeStringHostname(name)
+
+	inv.Name = strings.ToLower(sanitizeHostname.ReplaceAllString(name, "-"))
+
+	log.Debugf("Parsing labels from System Data")
+
+	if inv.Labels == nil {
+		inv.Labels = map[string]string{}
+	}
+
+	for k, v := range reg.Spec.MachineInventoryLabels {
+		log.Debugf("Parsing: %v : %v", k, v)
+
+		parsedData, err := replaceStringData(labels, v)
+		if err != nil {
+			if errors.Is(err, errValueNotFound) {
+				log.Debugf("Value not found: %v", v)
+				continue
+			}
+			log.Errorf("Failed parsing system data: %v", err.Error())
+			return err
+		}
+		parsedData = sanitizeString(parsedData)
+
+		log.Debugf("Parsed %s into %s with system data, setting it to label %s", v, parsedData, k)
+		inv.Labels[k] = strings.TrimSuffix(strings.TrimPrefix(parsedData, "-"), "-")
+	}
+
+	return nil
+}
+func replaceStringData(data map[string]interface{}, name string) (string, error) {
+	str := name
+	result := &strings.Builder{}
+	for {
+		i := strings.Index(str, "${")
+		if i == -1 {
+			result.WriteString(str)
+			break
+		}
+		j := strings.Index(str[i:], "}")
+		if j == -1 {
+			result.WriteString(str)
+			break
+		}
+
+		result.WriteString(str[:i])
+		obj := values.GetValueN(data, strings.Split(str[i+2:j+i], "/")...)
+		if str, ok := obj.(string); ok {
+			result.WriteString(str)
+		} else {
+			return "", errValueNotFound
+		}
+		str = str[j+i+1:]
+	}
+
+	return result.String(), nil
+}

--- a/pkg/server/labeltmpl.go
+++ b/pkg/server/labeltmpl.go
@@ -83,7 +83,9 @@ func updateInventoryLabels(tmpl templater.Templater, inv *elementalv1.MachineInv
 	return nil
 }
 
-func updateInventoryWithLabels(inventory *elementalv1.MachineInventory, data []byte) error {
+// mergeInventoryLabels: DEPRECATED
+// Used to merge client side labels, now deprecated would just skip and log an error.
+func mergeInventoryLabels(inventory *elementalv1.MachineInventory, data []byte) error {
 	labels := map[string]string{}
 	if err := json.Unmarshal(data, &labels); err != nil {
 		return fmt.Errorf("cannot extract inventory labels: %w", err)
@@ -96,7 +98,9 @@ func updateInventoryWithLabels(inventory *elementalv1.MachineInventory, data []b
 	return nil
 }
 
-func updateInventoryWithAnnotations(data []byte, mInventory *elementalv1.MachineInventory) error {
+// mergeInventoryAnnotations: merge annotations from the client, which include dynamic data,
+// e.g., the IP address. All annotation keys are prepended with "elemental.cattle.io/".
+func mergeInventoryAnnotations(data []byte, mInventory *elementalv1.MachineInventory) error {
 	annotations := map[string]string{}
 	if err := json.Unmarshal(data, &annotations); err != nil {
 		return fmt.Errorf("cannot extract inventory annotations: %w", err)

--- a/pkg/templater/templater.go
+++ b/pkg/templater/templater.go
@@ -34,7 +34,7 @@ type Templater interface {
 	Decode(str string) (string, error)
 }
 
-func NewTemplater() *templater {
+func NewTemplater() Templater {
 	return &templater{
 		data: map[string]interface{}{},
 	}

--- a/pkg/templater/templater.go
+++ b/pkg/templater/templater.go
@@ -1,0 +1,85 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templater
+
+import (
+	"errors"
+	"strings"
+
+	values "github.com/rancher/wrangler/v2/pkg/data"
+)
+
+var errValueNotFound = errors.New("value not found")
+
+func IsValueNotFoundError(err error) bool {
+	return errors.Is(err, errValueNotFound)
+}
+
+type Templater interface {
+	Fill(data map[string]interface{})
+	Decode(str string) (string, error)
+}
+
+func NewTemplater() *templater {
+	return &templater{
+		data: map[string]interface{}{},
+	}
+}
+
+var _ Templater = (*templater)(nil)
+
+type templater struct {
+	data map[string]interface{}
+}
+
+func (t *templater) Fill(data map[string]interface{}) {
+	for k, v := range data {
+		t.data[k] = v
+	}
+}
+
+func (t *templater) Decode(str string) (string, error) {
+	return replaceStringData(t.data, str)
+}
+
+func replaceStringData(data map[string]interface{}, name string) (string, error) {
+	str := name
+	result := &strings.Builder{}
+	for {
+		i := strings.Index(str, "${")
+		if i == -1 {
+			result.WriteString(str)
+			break
+		}
+		j := strings.Index(str[i:], "}")
+		if j == -1 {
+			result.WriteString(str)
+			break
+		}
+
+		result.WriteString(str[:i])
+		obj := values.GetValueN(data, strings.Split(str[i+2:j+i], "/")...)
+		if str, ok := obj.(string); ok {
+			result.WriteString(str)
+		} else {
+			return "", errValueNotFound
+		}
+		str = str[j+i+1:]
+	}
+
+	return result.String(), nil
+}

--- a/pkg/templater/templater_test.go
+++ b/pkg/templater/templater_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright © 2022 - 2024 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templater
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFillAndDecode(t *testing.T) {
+	data := map[string]interface{}{
+		"level1A": map[string]interface{}{
+			"level2A": "level2AValue",
+			"level2B": map[string]interface{}{
+				"level3A": "level3AValue",
+			},
+		},
+		"level1B": "level1BValue",
+		"Troublesome": map[string]interface{}{
+			"emptyData":   "",
+			"noStringVal": 5,
+		},
+	}
+
+	testCase := []struct {
+		Format string
+		Output string
+		Error  string
+	}{
+		{
+			Format: "${level1B}",
+			Output: "level1BValue",
+		},
+		{
+			Format: "${level1B",
+			Output: "${level1B",
+		},
+		{
+			Format: "a${level1B",
+			Output: "a${level1B",
+		},
+		{
+			Format: "${}",
+			Error:  "value not found",
+		},
+		{
+			Format: "${",
+			Output: "${",
+		},
+		{
+			Format: "a${",
+			Output: "a${",
+		},
+		{
+			Format: "${level1A}",
+			Error:  "value not found",
+		},
+		{
+			Format: "a${level1A}c",
+			Error:  "value not found",
+		},
+		{
+			Format: "a${level1A}",
+			Error:  "value not found",
+		},
+		{
+			Format: "${level1A}c",
+			Error:  "value not found",
+		},
+		{
+			Format: "a${level1A/level2A}c",
+			Output: "alevel2AValuec",
+		},
+		{
+			Format: "a${level1A/level2B/level3A}c",
+			Output: "alevel3AValuec",
+		},
+		{
+			Format: "a${level1A/level2B/level3A}c${level1B}",
+			Output: "alevel3AValueclevel1BValue",
+		},
+		{
+			Format: "a${unknown}",
+			Error:  "value not found",
+		},
+		{
+			Format: "${Troublesome/emptyData}",
+			Output: "",
+		},
+		{
+			Format: "${Troublesome/noStringVal}",
+			Error:  "value not found",
+		},
+	}
+
+	tmpl := NewTemplater()
+	tmpl.Fill(data)
+	for _, testCase := range testCase {
+		t.Run(testCase.Format, func(t *testing.T) {
+			str, err := tmpl.Decode(testCase.Format)
+			if testCase.Error == "" {
+				assert.NilError(t, err)
+				assert.Equal(t, testCase.Output, str, "'%s' not equal to '%s'", testCase.Output, str)
+			} else {
+				assert.Equal(t, testCase.Error, err.Error())
+			}
+		})
+	}
+}
+
+func TestIsValueNotFoundError(t *testing.T) {
+	errRandom := fmt.Errorf("random error")
+
+	assert.Equal(t, IsValueNotFoundError(errValueNotFound), true)
+	assert.Equal(t, IsValueNotFoundError(errRandom), false)
+}


### PR DESCRIPTION
Reworked the code to provide templating to MachineInventory labels and name.
The template source data is the "System Information" (BIOS) and "System Data" (which we usually called 'HW Labels') data sent by the machines via the register client.

This rework fixes some bugs and duplicated code and slightly changes the behavior in few cases.
The behavioral changes address the following corner cases:
* `.` is added to the allowed characters in label values (previously was substituted with `-`).
* when the first character of a label value is an accepted one but not alphanumeric (i.e., `-` , `_` or `.`) we drop it (previously we prepended `m` to the label).
* if the last character of a label value is not alphanumeric (i.e., `-` , `_` or `.`) we drop it (previously was not checked).
note that for the MachineInventory name (which will also be the machine hostname after k8s provisioning) the allowed set of characters has not changed: it's the same of the label case but without the `_` (i.e., `-` or `.`).

 Regarding the MachineRegistration.spec.machineName:
* if it is empty, a default `m-${UUID}` value is assigned to the MachineInventory.name (as previously)
* if it contains a template value which doesn't exists (wrong template value or `nosmbios` option) the MachineInventory.name is assigned a default `m-${UUID}` name (new behavior).
* if it is not empty, but after resolving the template values and sanitizing the string it gets empty, the name assignment process will error out failing the registration process.

Fixes #807 