### PR TITLE
[v1.6.x][BACKPORT] register: always register when called

### DIFF
--- a/cmd/register/main.go
+++ b/cmd/register/main.go
@@ -100,11 +100,6 @@ func newCommand(fs vfs.FS, client register.Client, stateHandler register.StateHa
 			if err != nil {
 				return fmt.Errorf("getting registration state: %w", err)
 			}
-			// Determine if registration should execute or skip a cycle
-			if !installation && !reset && !registrationState.HasLastUpdateElapsed(registrationUpdateSuppressTimer) {
-				log.Info("Nothing to do")
-				return nil
-			}
 			// Validate CA
 			caCert, err := getRegistrationCA(fs, cfg)
 			if err != nil {

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -86,7 +86,6 @@ var (
 	}
 	stateFixture = register.State{
 		InitialRegistration: time.Date(2023, time.August, 2, 12, 35, 10, 3, time.UTC),
-		LastUpdate:          time.Time{},
 		EmulatedTPM:         true,
 		EmulatedTPMSeed:     987654321,
 	}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -97,7 +97,6 @@ func (r *client) Register(reg elementalv1.Registration, caCert []byte, state *St
 		if err := sendUpdateData(conn); err != nil {
 			return nil, fmt.Errorf("failed to send update data: %w", err)
 		}
-		state.LastUpdate = time.Now()
 	} else {
 		state.InitialRegistration = time.Now()
 	}

--- a/pkg/register/state.go
+++ b/pkg/register/state.go
@@ -31,17 +31,12 @@ import (
 
 type State struct {
 	InitialRegistration time.Time `yaml:"initialRegistration,omitempty"`
-	LastUpdate          time.Time `yaml:"lastUpdate,omitempty"`
 	EmulatedTPM         bool      `yaml:"emulatedTPM,omitempty"`
 	EmulatedTPMSeed     int64     `yaml:"emulatedTPMSeed,omitempty"`
 }
 
 func (s *State) IsUpdatable() bool {
 	return !s.InitialRegistration.IsZero()
-}
-
-func (s *State) HasLastUpdateElapsed(suppress time.Duration) bool {
-	return time.Now().After(s.LastUpdate.Add(suppress))
 }
 
 type StateHandler interface {

--- a/pkg/register/state_test.go
+++ b/pkg/register/state_test.go
@@ -37,10 +37,8 @@ func TestRegister(t *testing.T) {
 var (
 	testStateDir  = "/test/register/state"
 	testStatePath = fmt.Sprintf("%s/%s", testStateDir, "state.yaml")
-	loc, _        = time.LoadLocation("Europe/Berlin")
 	stateFixture  = State{
 		InitialRegistration: time.Now().UTC(),
-		LastUpdate:          time.Now().UTC(),
 		EmulatedTPM:         true,
 		EmulatedTPMSeed:     123456789,
 	}
@@ -56,19 +54,6 @@ var _ = Describe("is state updatable", Label("registration", "state"), func() {
 			InitialRegistration: time.Now(),
 		}
 		Expect(state.IsUpdatable()).To(BeTrue())
-	})
-})
-
-var _ = Describe("has state update elapsed", Label("registration", "state"), func() {
-	It("returns false if the state is new", func() {
-		state := State{}
-		Expect(state.HasLastUpdateElapsed(-1 * time.Hour)).To(BeTrue())
-	})
-	It("returns true last update time is more than suppress timer ago", func() {
-		state := State{
-			LastUpdate: time.Now().Add(-10 * time.Hour),
-		}
-		Expect(state.HasLastUpdateElapsed(1 * time.Hour)).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
Remove the static check to re-register only after 24 hours. The re-registration will then happen every time the elemental-register client is called.
This static timer was introduced to limit as much as possible the communication form the host to Rancher and save communication bandwidth for remote clients.
Anyway, this makes not much sense as long as the elemental-system-agent is running, which will in any case keep connecting to Rancher. The call to the elemental-register binary is performed on official Elemental SLE Micro images every 30 minutes and at each boot.

Fixes https://github.com/rancher/elemental-operator/issues/811

(cherry picked from commit 36468aba429ec2e4472b5762b8a400f9c2c363a4)

Backport of #813 