### PR TITLE
networking: use the main registration websocket channel for network data

### DIFF
--- a/cmd/register/main_test.go
+++ b/cmd/register/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -276,15 +275,13 @@ var _ = Describe("elemental-register --install", Label("registration", "cli", "i
 			stateHandler.EXPECT().Save(stateFixture).Return(nil)
 		})
 		It("should trigger install when --install argument", func() {
-			wantConfigJson, err := json.Marshal(networkConfigFixture)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			cmd.SetArgs([]string{"--install"})
-			client.EXPECT().GetNetworkConfig(alternateConfigFixture.Elemental.Registration, []byte(alternateConfigFixture.Elemental.Registration.CACert), gomock.Any()).Return(wantConfigJson, nil)
 			installer.EXPECT().InstallElemental(alternateConfigFixture, stateFixture, networkConfigFixture).Return(nil)
 			client.EXPECT().
 				Register(baseConfigFixture.Elemental.Registration, []byte(baseConfigFixture.Elemental.Registration.CACert), &stateFixture).
-				Return(marshalToBytes(alternateConfigFixture), nil)
+				Return(append(marshalToBytes(alternateConfigFixture), marshalToBytes(networkConfigFixture)...), nil)
 			Expect(cmd.Execute()).ToNot(HaveOccurred())
 		})
 	})
@@ -354,15 +351,13 @@ var _ = Describe("elemental-register --reset", Label("registration", "cli", "res
 			stateHandler.EXPECT().Save(register.State{}).Return(nil)
 		})
 		It("should trigger reset when --reset argument", func() {
-			wantConfigJson, err := json.Marshal(networkConfigFixture)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			cmd.SetArgs([]string{"--reset"})
-			client.EXPECT().GetNetworkConfig(alternateConfigFixture.Elemental.Registration, []byte(alternateConfigFixture.Elemental.Registration.CACert), gomock.Any()).Return(wantConfigJson, nil)
 			installer.EXPECT().ResetElemental(alternateConfigFixture, register.State{}, networkConfigFixture).Return(nil)
 			client.EXPECT().
 				Register(baseConfigFixture.Elemental.Registration, []byte(baseConfigFixture.Elemental.Registration.CACert), &register.State{}).
-				Return(marshalToBytes(alternateConfigFixture), nil)
+				Return(append(marshalToBytes(alternateConfigFixture), marshalToBytes(networkConfigFixture)...), nil)
 			Expect(cmd.Execute()).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/register/mocks/client.go
+++ b/pkg/register/mocks/client.go
@@ -58,21 +58,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// GetNetworkConfig mocks base method.
-func (m *MockClient) GetNetworkConfig(arg0 v1beta1.Registration, arg1 []byte, arg2 *register.State) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNetworkConfig", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNetworkConfig indicates an expected call of GetNetworkConfig.
-func (mr *MockClientMockRecorder) GetNetworkConfig(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkConfig", reflect.TypeOf((*MockClient)(nil).GetNetworkConfig), arg0, arg1, arg2)
-}
-
 // Register mocks base method.
 func (m *MockClient) Register(arg0 v1beta1.Registration, arg1 []byte, arg2 *register.State) ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Now the network data is piggybacked to the elemental data during registration.
This way the registering client doesn't need to open a separate connection after the registration is done.