### PR TITLE
Random template labels - avoid override

### DIFF
--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -477,6 +477,10 @@ func assertSystemDataLabels(t *testing.T, inventory *elementalv1.MachineInventor
 func TestUpdateInventoryLabels(t *testing.T) {
 	inventory := &elementalv1.MachineInventory{}
 	inventory.Name = "${System Data/Runtime/Hostname}"
+	inventory.Labels = map[string]string{
+		"elemental.cattle.io/Random01": "alreadyFilled",
+		"elemental.cattle.io/Random02": "",
+	}
 
 	registration := &elementalv1.MachineRegistration{
 		Spec: elementalv1.MachineRegistrationSpec{
@@ -496,6 +500,9 @@ func TestUpdateInventoryLabels(t *testing.T) {
 				"elemental.cattle.io/BlockDevice0-Removable": "${System Data/Block Devices/testdisk1/Removable}",
 				"elemental.cattle.io/BlockDevice1-Removable": "${System Data/Block Devices/testdisk2/Removable}",
 				"elemental.cattle.io/UnexistingTemplate":     "${System Data/Not Existing Value}",
+				"elemental.cattle.io/Random01":               "my-random-value-${Random/Int/1000}",
+				"elemental.cattle.io/Random02":               "${Random/UUID}",
+				"elemental.cattle.io/Random03":               "my-random-value-${Random/Hex/5}",
 			},
 		},
 	}
@@ -572,6 +579,10 @@ func TestUpdateInventoryLabels(t *testing.T) {
 	// Check values were sanitized
 	assert.Equal(t, len(validation.IsValidLabelValue(inventory.Labels["elemental.cattle.io/CpuModel"])), 0)
 	assert.Equal(t, len(validation.IsValidLabelValue(inventory.Labels["elemental.cattle.io/CpuVendor"])), 0)
+	// Check Random label templates
+	assert.Equal(t, inventory.Labels["elemental.cattle.io/Random01"], "alreadyFilled")
+	assert.Equal(t, len(inventory.Labels["elemental.cattle.io/Random02"]), len("e511d5ca-a765-42f2-82b7-264f37ffb329"))
+	assert.Equal(t, len(inventory.Labels["elemental.cattle.io/Random03"]), 5+len("my-random-value-"))
 }
 
 func TestUpdateInventoryName(t *testing.T) {

--- a/pkg/templater/random.go
+++ b/pkg/templater/random.go
@@ -38,6 +38,11 @@ const (
 	tmplIntKey    = "Int"
 )
 
+// IsRandomLabel returns true if s contains a $Random template variable
+func IsRandomLabel(s string) bool {
+	return strings.Contains(s, "${"+tmplRandomKey)
+}
+
 func isRandomTemplate(tmplVal []string) bool {
 	if tmplVal[0] != tmplRandomKey {
 		return false


### PR DESCRIPTION
MachineRegistration template labels are rendered to MachineInventory labels at every (re-)registration.
Every Elemental host re-registers regularly, so each time this happens, the MachineRegistration rendered labels overwrite the labels in the MachineInventory resource associated with the host.
This makes sense for the Hardware Template Variables (imagine the host is switched off, changed in the HW, e.g., RAM augmented or CPU swapped, and then rebooted) and for all the Template Variables tracking the host data.
For the recently added Random Template Variables instead this should not happen, otherwise the Random part will be changed at every re-registration.

This PR checks if the MachineRegistration template label to be rendered contains a Random Template Variable and if a value for the same label (i.e., for the same label key) is already present in the MachineInventory associated to the registering host: if so, the already existing label in the MachineInventory is left untouched.
If the template label is instead missing from the MachineInventory or it is present but is an empty string, the MachineInventory label will be updated with the value rendered from the MachineRegistration template label as usual.