### PR TITLE
operator: add Registry to ManagedOSVersionChannels Spec

### DIFF
--- a/.obs/chartfile/crds/templates/crds.yaml
+++ b/.obs/chartfile/crds/templates/crds.yaml
@@ -2730,6 +2730,11 @@ spec:
                 type: boolean
               options:
                 x-kubernetes-preserve-unknown-fields: true
+              registry:
+                description: |-
+                  Registry defines a common registry to be prepended to the 'uri' or 'upgradeImage'
+                  of each extracted ManagedOSVersion resource.
+                type: string
               syncInterval:
                 default: 1h
                 type: string

--- a/api/v1beta1/managedosversionchannel_types.go
+++ b/api/v1beta1/managedosversionchannel_types.go
@@ -47,6 +47,10 @@ type ManagedOSVersionChannelSpec struct {
 	// +optional
 	// +kubebuilder:default:=true
 	Enabled bool `json:"enabled"`
+	// Registry defines a common registry to be prepended to the 'uri' or 'upgradeImage'
+	// of each extracted ManagedOSVersion resource.
+	// +optional
+	Registry string `json:"registry,omitempty"`
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
 	// +optional

--- a/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
+++ b/config/crd/bases/elemental.cattle.io_managedosversionchannels.yaml
@@ -48,6 +48,11 @@ spec:
                 type: boolean
               options:
                 x-kubernetes-preserve-unknown-fields: true
+              registry:
+                description: |-
+                  Registry defines a common registry to be prepended to the 'uri' or 'upgradeImage'
+                  of each extracted ManagedOSVersion resource.
+                type: string
               syncInterval:
                 default: 1h
                 type: string


### PR DESCRIPTION
The new Registry field allows to prepend a common registry to the image URLs of the embedded ManagedOSVersion resources.

Fixes #549