### PR TITLE
Align values.yaml and questions.yaml

### DIFF
--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -8,13 +8,13 @@ questions:
   group: "Elemental OS Channel"
   subquestions:
   - variable: channel.image
-    default: "%%IMG_REPO%%/rancher/elemental-channel"
+    default: "%%IMG_REPO%%/rancher/elemental-channel/sl-micro"
     description: "Specify the Elemental OS channel: for air-gapped scenarios you need to provide your own OS channel image (see https://elemental.docs.rancher.com/airgap for detailed instructions)"
     type: string
     label: Elemental OS Channel Image
     group: "Elemental OS Channel"
   - variable: channel.tag
-    default: "%VERSION%"
+    default: "6.0-baremetal"
     description: "Specify Elemental OS channel image tag"
     type: string
     label: "Elemental OS Channel Tag"


### PR DESCRIPTION
Sets default tag and image repository in questions.yaml to the same values as we have in `values.yaml`

Part of #837