### PR TITLE
Label Templates: rework collection of 'hostinfo' data and collected variables

### DIFF
--- a/cmd/register/showdata.go
+++ b/cmd/register/showdata.go
@@ -19,21 +19,29 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/rancher/elemental-operator/pkg/dmidecode"
 	"github.com/rancher/elemental-operator/pkg/hostinfo"
 	"github.com/rancher/elemental-operator/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"sigs.k8s.io/yaml"
 )
 
 const (
-	DUMPHW     = "hardware"
-	DUMPSMBIOS = "smbios"
+	DUMPLEGACY        = "legacy"
+	DUMPSMBIOS        = "smbios"
+	DUMPHOSTINFO      = "hostinfo"
+	FORMATLABELS      = "labels"
+	FORMATJSON        = "json"
+	FORMATJSONCOMPACT = "json-compact"
+	FORMATYAML        = "yaml"
 )
 
 func newDumpDataCommand() *cobra.Command {
 	var raw bool
+	var format string
 
 	cmd := &cobra.Command{
 		Use:     "dumpdata",
@@ -41,64 +49,120 @@ func newDumpDataCommand() *cobra.Command {
 		Short:   "Show host data sent during the registration phase",
 		Long: "Prints to stdout the data sent by the registering client " +
 			"to the Elemental Operator.\nTakes the type of host data to dump " +
-			"as argument, be it '" + DUMPHW + "' or '" + DUMPSMBIOS + "'.",
+			"as argument, be it '" + DUMPHOSTINFO + "' (default), " + DUMPLEGACY +
+			"' or '" + DUMPSMBIOS + "'.",
 		Args:      cobra.MatchAll(cobra.MaximumNArgs(1), cobra.OnlyValidArgs),
-		ValidArgs: []string{DUMPHW, DUMPSMBIOS},
+		ValidArgs: []string{DUMPHOSTINFO, DUMPLEGACY, DUMPSMBIOS},
 		RunE: func(_ *cobra.Command, args []string) error {
-			return dumpdata(args, raw)
+			return dumpdata(args, format, raw)
 		},
 	}
 
 	viper.AutomaticEnv()
-	cmd.Flags().BoolVarP(&raw, "raw", "r", false, "dump raw data before conversion to label templates' variables")
+	cmd.Flags().BoolVarP(&raw, "raw", "r", false, "dump all collected raw data before postprocessing to refine available label templates variables")
 	_ = viper.BindPFlag("raw", cmd.Flags().Lookup("raw"))
-
+	cmd.Flags().StringVarP(&format, "format", "f", FORMATLABELS, "ouput format ['"+FORMATLABELS+"', '"+FORMATYAML+"', '"+FORMATJSON+"', '"+FORMATJSONCOMPACT+"']")
+	_ = viper.BindPFlag("format", cmd.Flags().Lookup("format"))
 	return cmd
 }
 
-func dumpdata(args []string, raw bool) error {
-	dataType := "hardware"
+func dumpdata(args []string, format string, raw bool) error {
+	dataType := "hostinfo"
 	if len(args) > 0 {
 		dataType = args[0]
 	}
 
-	var hostData interface{}
+	var mapData map[string]interface{}
 
 	switch dataType {
-	case DUMPHW:
+	case DUMPHOSTINFO:
+		hostData, err := hostinfo.Host()
+		if err != nil {
+			log.Fatalf("Cannot retrieve host data: %s", err)
+		}
+
+		if raw {
+			mapData = hostinfo.ExtractFullData(hostData)
+		} else {
+			mapData = hostinfo.ExtractLabels(hostData)
+		}
+	case DUMPLEGACY:
 		hwData, err := hostinfo.Host()
 		if err != nil {
 			log.Fatalf("Cannot retrieve host data: %s", err)
 		}
 
 		if raw {
-			hostData = hwData
+			mapData = hostinfo.ExtractFullData(hwData)
 		} else {
-			dataMap, err := hostinfo.ExtractLabels(hwData)
-			if err != nil {
-				log.Fatalf("Cannot convert host data to labels: %s", err)
-			}
-			hostData = dataMap
+			mapData = hostinfo.ExtractLabelsLegacy(hwData)
 		}
-
 	case DUMPSMBIOS:
 		smbiosData, err := dmidecode.Decode()
 		if err != nil {
 			log.Fatalf("Cannot retrieve SMBIOS data: %s", err)
 		}
 
-		hostData = smbiosData
-
+		mapData = smbiosData
 	default:
 		// Should never happen but manage it anyway
 		log.Fatalf("Unsupported data type: %s", dataType)
 	}
 
-	jsonData, err := json.MarshalIndent(hostData, "", "  ")
-	if err != nil {
-		log.Fatalf("Cannot convert host data to json: %s", err)
+	var serializedData []byte
+	var err error
+
+	switch format {
+	case FORMATLABELS:
+		labels := map2Labels("", mapData)
+		keys := make([]string, 0, len(labels))
+		for k := range labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			fmt.Printf("%-52s: %q\n", k, labels[k])
+		}
+		return nil
+	case FORMATJSON:
+		serializedData, err = json.MarshalIndent(mapData, "", "  ")
+	case FORMATJSONCOMPACT:
+		serializedData, err = json.Marshal(mapData)
+	case FORMATYAML:
+		serializedData, err = yaml.Marshal(mapData)
+	default:
+		// Should never happen but manage it anyway
+		log.Fatalf("Unsupported output type: %s", format)
 	}
-	fmt.Printf("%s\n", string(jsonData))
+
+	if err != nil {
+		log.Fatalf("Cannot convert host data to %s: %s", format, err)
+	}
+	fmt.Printf("%s\n", string(serializedData))
 
 	return nil
+}
+
+func map2Labels(rootKey string, data map[string]interface{}) map[string]string {
+	ret := map[string]string{}
+
+	for key, val := range data {
+		lbl := key
+		if len(rootKey) > 0 {
+			lbl = rootKey + "/" + lbl
+		}
+		if _, ok := val.(string); ok {
+			lbl = "${" + lbl + "}"
+			ret[lbl] = fmt.Sprintf("%s", val)
+			continue
+		}
+		if _, ok := val.(map[string]interface{}); !ok {
+			continue
+		}
+		for k, v := range map2Labels(lbl, val.(map[string]interface{})) {
+			ret[k] = v
+		}
+	}
+	return ret
 }

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -274,6 +274,10 @@ func sendSystemData(conn *websocket.Conn, protoVersion MessageType) error {
 	if protoVersion >= MsgSystemDataV2 {
 		log.Info("Sending System Data")
 		labels := hostinfo.ExtractLabels(data)
+		// Add legacy labels too (to be deprecated and removed sooner or later)
+		for k, v := range hostinfo.ExtractLabelsLegacy(data) {
+			labels[k] = v
+		}
 		if err != nil {
 			return fmt.Errorf("extracting labels from system data: %w", err)
 		}

--- a/pkg/register/register.go
+++ b/pkg/register/register.go
@@ -273,7 +273,7 @@ func sendSystemData(conn *websocket.Conn, protoVersion MessageType) error {
 
 	if protoVersion >= MsgSystemDataV2 {
 		log.Info("Sending System Data")
-		labels, err := hostinfo.ExtractLabels(data)
+		labels := hostinfo.ExtractLabels(data)
 		if err != nil {
 			return fmt.Errorf("extracting labels from system data: %w", err)
 		}

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -436,9 +436,7 @@ func TestUpdateInventoryFromSystemDataNG(t *testing.T) {
 	inventory := &elementalv1.MachineInventory{}
 	tmpl := templater.NewTemplater()
 
-	data, err := hostinfo.ExtractLabels(hostInfoFixture)
-	assert.NilError(t, err)
-
+	data := hostinfo.ExtractLabelsLegacy(hostInfoFixture)
 	encodedData, err := json.Marshal(data)
 	assert.NilError(t, err)
 

--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -77,7 +77,29 @@ var (
 			},
 		},
 	}
-
+	hostinfoDataLabelsRegistrationFixture = &elementalv1.MachineRegistration{
+		Spec: elementalv1.MachineRegistrationSpec{
+			MachineInventoryLabels: map[string]string{
+				"elemental.cattle.io/Hostname":               "${Runtime/Hostname}",
+				"elemental.cattle.io/TotalMemory":            "${Memory/TotalPhysicalBytes}",
+				"elemental.cattle.io/AvailableMemory":        "${Memory/TotalUsableBytes}",
+				"elemental.cattle.io/CpuTotalCores":          "${CPU/TotalCores}",
+				"elemental.cattle.io/CpuTotalThreads":        "${CPU/TotalThreads}",
+				"elemental.cattle.io/NetIfacesNumber":        "${Network/TotalNICs}",
+				"elemental.cattle.io/NetIface0-Name":         "${Network/NICs/myNic1/Name}",
+				"elemental.cattle.io/NetIface0-MAC":          "${Network/NICs/myNic1/MacAddress}",
+				"elemental.cattle.io/NetIface0-IsVirtual":    "${Network/NICs/myNic1/IsVirtual}",
+				"elemental.cattle.io/NetIface1-Name":         "${Network/NICs/myNic2/Name}",
+				"elemental.cattle.io/BlockDevicesNumber":     "${Storage/TotalDisks}",
+				"elemental.cattle.io/BlockDevice0-Name":      "${Storage/Disks/testdisk1/Name}",
+				"elemental.cattle.io/BlockDevice1-Name":      "${Storage/Disks/testdisk2/Name}",
+				"elemental.cattle.io/BlockDevice0-Size":      "${Storage/Disks/testdisk1/Size}",
+				"elemental.cattle.io/BlockDevice1-Size":      "${Storage/Disks/testdisk2/Size}",
+				"elemental.cattle.io/BlockDevice0-Removable": "${Storage/Disks/testdisk1/Removable}",
+				"elemental.cattle.io/BlockDevice1-Removable": "${Storage/Disks/testdisk2/Removable}",
+			},
+		},
+	}
 	hostInfoFixture = hostinfo.HostInfo{
 		Block: &block.Info{
 			Disks: []*block.Disk{
@@ -446,6 +468,24 @@ func TestUpdateInventoryFromSystemDataNG(t *testing.T) {
 
 	tmpl.Fill(systemData)
 	err = updateInventoryLabels(tmpl, inventory, systemDataLabelsRegistrationFixture)
+	assert.NilError(t, err)
+	assertSystemDataLabels(t, inventory)
+}
+
+func TestUpdateInventoryFromHostinfoData(t *testing.T) {
+	inventory := &elementalv1.MachineInventory{}
+	tmpl := templater.NewTemplater()
+
+	data := hostinfo.ExtractLabels(hostInfoFixture)
+	encodedData, err := json.Marshal(data)
+	assert.NilError(t, err)
+
+	hostinfoData := map[string]interface{}{}
+	err = json.Unmarshal(encodedData, &hostinfoData)
+	assert.NilError(t, err)
+	fmt.Printf("%+v\n", hostinfoData)
+	tmpl.Fill(hostinfoData)
+	err = updateInventoryLabels(tmpl, inventory, hostinfoDataLabelsRegistrationFixture)
 	assert.NilError(t, err)
 	assertSystemDataLabels(t, inventory)
 }


### PR DESCRIPTION
Quite some changes in this PR:
* Allow automatic conversion of data to map[string]interface{} (Label Templates format) using reflection; still, collect manually partial data from the hostinfo data for some subsystems to just pick useful data.
* Use variable names from hostinfo: in particular, drop spaces in variable names.
* Try to keep consistent variable names/path.
* Expose NICs and Disks also by number, to enable listing also when the device name is not known.
* Get SMBIOS data directly from hostinfo with update var names: `System Information` data still transmitted in parallel but deprecated (and when removed we can drop also the dmidecode tool requirement).
* Keep the old variable naming enabled: they should be now deprecated and removed in the future.

The `elemental-registry dump` command now allows to print the three label data sets ('smbios', 'legacy' and 'hostinfo', where 'hostinfo' is the new set) in different formats (actual labels, json or yaml).

Fixes https://github.com/rancher/elemental-operator/issues/834

Replaces #840