### PR TITLE
Update helper scripts to 1.6.x channel setup

### DIFF
--- a/.obs/helper_scripts/checkimages.sh
+++ b/.obs/helper_scripts/checkimages.sh
@@ -58,3 +58,6 @@ channels=$(findChannels "${OPERATOR_IMAGES}")
 for channel in ${channels}; do
   checkChannel ${channel}
 done
+
+echo "All images successfully checked!"
+exit 0

--- a/.obs/helper_scripts/listimages.sh
+++ b/.obs/helper_scripts/listimages.sh
@@ -38,8 +38,14 @@ done
 echo "${REGISTRY}/rancher/elemental-operator:${OPERATOR}"
 echo "${REGISTRY}/rancher/seedimage-builder:${OPERATOR}"
 
-echo "${REGISTRY}/rancher/elemental-channel:${OPERATOR}"
-echo "${REGISTRY}/rancher/elemental-rt-channel:${OPERATOR}"
+# Note sort -V is a natural numbering sort, not semver
+higher_ver=$(printf '%s\n' "${OPERATOR}" "1.6.0" | sort -rV | head -n1)
+if [ "${higher_ver}" == "1.6.0" ]; then
+  echo "${REGISTRY}/rancher/elemental-channel:${OPERATOR}"
+  echo "${REGISTRY}/rancher/elemental-rt-channel:${OPERATOR}"
+else
+  echo "${REGISTRY}/rancher/elemental-channel/sl-micro:6.0-baremetal"
+fi
 
 # Assume if not registry.suse.com it should be some OBS path, hence
 # charts require a different repository than containers


### PR DESCRIPTION
I am not sure about the relevance of this script with the new channels scheme. At a time I coded these scripts to list elemental-operator images and to validate channels, but this is loosing it's meaning, now the contents of OS channels are validated by design (we create the contents of it by querying the actual registry) and the channel image itself is decoupled from the operator.

In any case this is just a trivial patch to keep it up to date and consistent.