### PR TITLE
Allow configuration of max snapshots during install

### DIFF
--- a/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
+++ b/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
@@ -867,12 +867,19 @@ spec:
                             type: boolean
                           snapshotter:
                             default:
+                              maxSnaps: 2
                               type: loopdevice
                             properties:
+                              maxSnaps:
+                                default: 2
+                                description: MaxSnaps sets the maximum amount of snapshots
+                                  to keep
+                                minimum: 2
+                                type: integer
                               type:
                                 default: loopdevice
-                                description: Type sets the snapshotter type a new
-                                  installation, available options are 'loopdevice'
+                                description: Type sets the snapshotter type for a
+                                  new installation, available options are 'loopdevice'
                                   and 'btrfs'
                                 type: string
                             type: object

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -53,15 +53,20 @@ type Install struct {
 	// +optional
 	ConfigDir string `json:"config-dir,omitempty" yaml:"config-dir,omitempty"`
 	// +optional
-	// +kubebuilder:default:={"type": "loopdevice"}
+	// +kubebuilder:default:={"type": "loopdevice", "maxSnaps": 2}
 	Snapshotter SnapshotterConfig `json:"snapshotter,omitempty" yaml:"snapshotter,omitempty"`
 }
 
 type SnapshotterConfig struct {
-	// Type sets the snapshotter type a new installation, available options are 'loopdevice' and 'btrfs'
+	// Type sets the snapshotter type for a new installation, available options are 'loopdevice' and 'btrfs'
 	// +optional
 	// +kubebuilder:default:=loopdevice
 	Type string `json:"type,omitempty" yaml:"type,omitempty"`
+	// MaxSnaps sets the maximum amount of snapshots to keep
+	// +optional
+	// +kubebuilder:default:=2
+	// +kubebuilder:validation:Minimum:=2
+	MaxSnaps int `json:"maxSnaps,omitempty" yaml:"maxSnaps,omitempty"`
 }
 
 type Reset struct {

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -97,12 +97,19 @@ spec:
                             type: boolean
                           snapshotter:
                             default:
+                              maxSnaps: 2
                               type: loopdevice
                             properties:
+                              maxSnaps:
+                                default: 2
+                                description: MaxSnaps sets the maximum amount of snapshots
+                                  to keep
+                                minimum: 2
+                                type: integer
                               type:
                                 default: loopdevice
-                                description: Type sets the snapshotter type a new
-                                  installation, available options are 'loopdevice'
+                                description: Type sets the snapshotter type for a
+                                  new installation, available options are 'loopdevice'
                                   and 'btrfs'
                                 type: string
                             type: object

--- a/pkg/elementalcli/elementalcli.go
+++ b/pkg/elementalcli/elementalcli.go
@@ -101,6 +101,7 @@ func mapToInstallEnv(conf elementalv1.Install) []string {
 	variables = append(variables, formatEV("ELEMENTAL_REBOOT", strconv.FormatBool(conf.Reboot)))
 	variables = append(variables, formatEV("ELEMENTAL_EJECT_CD", strconv.FormatBool(conf.EjectCD)))
 	variables = append(variables, formatEV("ELEMENTAL_SNAPSHOTTER_TYPE", conf.Snapshotter.Type))
+	variables = append(variables, formatEV("ELEMENTAL_SNAPSHOTTER_MAX_SNAPS", fmt.Sprintf("%d", conf.Snapshotter.MaxSnaps)))
 	variables = append(variables, formatEV("ELEMENTAL_CLOUD_INIT_PATHS", TempCloudInitDir))
 	return variables
 }


### PR DESCRIPTION
Depends on https://github.com/rancher/elemental-toolkit/pull/2193

```yaml
apiVersion: elemental.cattle.io/v1beta1
kind: MachineRegistration
metadata:
  name: fire-nodes
  namespace: fleet-default
spec:
    elemental:
      install:
        snapshotter:
          type: btrfs
          maxSnaps: 2
```

Note that the default (and minimum value) now is `2`. This differs from the previous `4` for `btrfs` snapshotter (was driven toolkit side).   

Also note that this covers `install` phase only. 
I considered implementing it for reset as well, however since you will actually be able to define a different snapshotter config on reset, this will make machine drift in behavior, depending if they are freshly provisioned or reset, which is not desirable imho.

Changing snapshotter type on reset also has consequences, for example switching from `btrfs` to `loopdevice` will have serious effects on partition sizes. Changing the amount of maxSnaps will also affect space available, and repartitioning is something we do not support on reset. 