### PR TITLE
Use privateCA for Rancher on dev environment

### DIFF
--- a/tests/manifests/cattle-system-namespace.yaml
+++ b/tests/manifests/cattle-system-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cattle-system

--- a/tests/manifests/test-private-ca.yaml
+++ b/tests/manifests/test-private-ca.yaml
@@ -1,0 +1,46 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-ca
+  namespace: cattle-system
+spec:
+  commonName: elemental-selfsigned-ca
+  duration: 94800h
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: elemental-selfsigned
+  renewBefore: 360h
+  secretName: tls-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-rancher-ingress
+  namespace: cattle-system
+spec:
+  dnsNames:
+  - 172.18.0.2.sslip.io
+  duration: 9480h
+  issuerRef:
+    kind: Issuer
+    name: elemental-ca
+  renewBefore: 360h
+  secretName: tls-rancher-ingress
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: elemental-ca
+  namespace: cattle-system
+spec:
+  ca:
+    secretName: tls-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: elemental-selfsigned
+  namespace: cattle-system
+spec:
+  selfSigned: {}


### PR DESCRIPTION
This PR here is to setup a private CA when installing Rancher. 
This enables testing with CA rotation/expiration and what not.

Also helper for https://github.com/rancher/elemental/issues/1604