### PR TITLE
Add support for agent-tls-mode Rancher setting

### DIFF
--- a/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
+++ b/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
@@ -939,6 +939,8 @@ spec:
                             type: string
                           secret-namespace:
                             type: string
+                          strictTLSMode:
+                            type: boolean
                           token:
                             type: string
                           url:

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -113,6 +113,8 @@ type Registration struct {
 
 type SystemAgent struct {
 	// +optional
+	StrictTLSMode bool `json:"strictTLSMode,omitempty" yaml:"strictTLSMode,omitempty"`
+	// +optional
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	// +optional
 	Token string `json:"token,omitempty" yaml:"token,omitempty"`

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -173,6 +173,8 @@ spec:
                             type: string
                           secret-namespace:
                             type: string
+                          strictTLSMode:
+                            type: boolean
                           token:
                             type: string
                           url:

--- a/pkg/install/_testdata/after-hook-config-install.yaml
+++ b/pkg/install/_testdata/after-hook-config-install.yaml
@@ -106,6 +106,13 @@ stages:
                                 connectionInfoFile: /var/lib/elemental/agent/elemental_connection.json
                               encoding: ""
                               ownerstring: ""
+                            - path: /etc/rancher/elemental/agent/envs
+                              permissions: 384
+                              owner: 0
+                              group: 0
+                              content: CATTLE_AGENT_STRICT_VERIFY="true"
+                              encoding: ""
+                              ownerstring: ""
               encoding: ""
               ownerstring: ""
           name: Elemental System Agent Config

--- a/pkg/install/_testdata/after-hook-config-reset.yaml
+++ b/pkg/install/_testdata/after-hook-config-reset.yaml
@@ -106,6 +106,13 @@ stages:
                                 connectionInfoFile: /var/lib/elemental/agent/elemental_connection.json
                               encoding: ""
                               ownerstring: ""
+                            - path: /etc/rancher/elemental/agent/envs
+                              permissions: 384
+                              owner: 0
+                              group: 0
+                              content: CATTLE_AGENT_STRICT_VERIFY="true"
+                              encoding: ""
+                              ownerstring: ""
               encoding: ""
               ownerstring: ""
           name: Elemental System Agent Config

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -76,6 +76,7 @@ var (
 				Reboot:          true,
 			},
 			SystemAgent: elementalv1.SystemAgent{
+				StrictTLSMode:   true,
 				URL:             "https://127.0.0.1.sslip.io/test/control/plane/endpoint",
 				Token:           "a test token",
 				SecretName:      "a test secret name",

--- a/tests/e2e/config/config.yaml
+++ b/tests/e2e/config/config.yaml
@@ -12,7 +12,7 @@ nginxURL: https://raw.githubusercontent.com/kubernetes/ingress-nginx/${NGINX_VER
 certManagerVersion: v1.14.2
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.8.2
+rancherVersion: 2.9.2
 rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz
 
 systemUpgradeControllerVersion: v0.13.4


### PR DESCRIPTION
Adds support for the [agent-tls-mode](https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/installation-references/tls-settings#agent-tls-enforcement).

In case this Rancher value is missing, we default to `strict` verification, which is the current behavior in elemental-operator.