### PR TITLE
RBAC: restrict SeedImage controller auth to fleet-default

### DIFF
--- a/.obs/chartfile/elemental-operator-helm/templates/rbac.yaml
+++ b/.obs/chartfile/elemental-operator-helm/templates/rbac.yaml
@@ -1,7 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: '{{ .Release.Name }}'
+  namespace: fleet-default
 rules:
 - apiGroups:
   - ""
@@ -18,6 +19,48 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ .Release.Name }}'
+rules:
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -31,19 +74,11 @@ rules:
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
   resources:
   - pods/log
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
   verbs:
   - get
 - apiGroups:
@@ -77,15 +112,7 @@ rules:
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/status
-  verbs:
-  - get
 - apiGroups:
   - cluster.x-k8s.io
   resources:
@@ -293,3 +320,31 @@ rules:
   - delete
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ .Release.Name }}'
+  namespace: fleet-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ .Release.Name }}'
+  namespace: fleet-default
+subjects:
+- kind: ServiceAccount
+  name: '{{ .Release.Name }}'
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ .Release.Name }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ .Release.Name }}'
+subjects:
+- kind: ServiceAccount
+  name: '{{ .Release.Name }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ build-crds: $(KUSTOMIZE)
 	$(KUSTOMIZE) build config/crd > .obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
 
 build-rbac: $(KUSTOMIZE)
-	$(KUSTOMIZE) build config/rbac > .obs/chartfile/elemental-operator-helm/templates/cluster_role.yaml
+	$(KUSTOMIZE) build config/rbac > .obs/chartfile/elemental-operator-helm/templates/rbac.yaml
 
 build-manifests: $(KUSTOMIZE) generate
 	$(MAKE) build-crds

--- a/config/rbac/bases/cluster_role_binding.yaml
+++ b/config/rbac/bases/cluster_role_binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}
+  name: manager-role
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}
+  name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
-  namespace: {{.Release.Namespace}}
+  name: manager-role
+  namespace: manager-role-namespace
 

--- a/config/rbac/bases/role.yaml
+++ b/config/rbac/bases/role.yaml
@@ -7,18 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
@@ -32,19 +20,11 @@ rules:
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
   resources:
   - pods/log
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
   verbs:
   - get
 - apiGroups:
@@ -78,15 +58,7 @@ rules:
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - services/status
-  verbs:
-  - get
 - apiGroups:
   - cluster.x-k8s.io
   resources:
@@ -294,3 +266,58 @@ rules:
   - delete
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manager-role
+  namespace: fleet-default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get

--- a/config/rbac/bases/role_binding.yaml
+++ b/config/rbac/bases/role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-role
+  namespace: fleet-default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manager-role
+  namespace: fleet-default
+subjects:
+- kind: ServiceAccount
+  name: manager-role
+  namespace: manager-role-namespace
+

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -2,11 +2,37 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - bases/role.yaml
+- bases/role_binding.yaml
+- bases/cluster_role_binding.yaml
 
-patchesJson6902: ## this is used to patch role name so we can use in helm chart template
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRole
-      name: manager-role
-    path: patches/name_in_role.yaml
+patches:
+- path: patches/name_in_role.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: manager-role
+    version: v1
+- path: patches/name_in_role.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRoleBinding
+    name: manager-role
+    version: v1
+- path: patches/name_in_role.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: Role
+    name: manager-role
+    version: v1
+- path: patches/name_in_rolebinding.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: RoleBinding
+    name: manager-role
+    version: v1
+- path: patches/name_in_rolebinding.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    kind: ClusterRoleBinding
+    name: manager-role
+    version: v1

--- a/config/rbac/patches/name_in_rolebinding.yaml
+++ b/config/rbac/patches/name_in_rolebinding.yaml
@@ -1,0 +1,9 @@
+- op: replace
+  path: /metadata/name
+  value: "{{ .Release.Name }}"
+- op: replace
+  path: /subjects/0/name
+  value: "{{ .Release.Name }}"
+- op: replace
+  path: /subjects/0/namespace
+  value: "{{ .Release.Namespace }}"

--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -66,11 +66,11 @@ const (
 // +kubebuilder:rbac:groups=elemental.cattle.io,resources=machineregistrations,verbs=get;watch;list
 // TODO: restrict access to resources to the required namespace only:
 //   https://github.com/rancher/elemental-operator/issues/457
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=pods/status,verbs=get
-// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=services/status,verbs=get
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",namespace=fleet-default,resources=pods,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",namespace=fleet-default,resources=pods/status,verbs=get
+// +kubebuilder:rbac:groups="",namespace=fleet-default,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",namespace=fleet-default,resources=services/status,verbs=get
+// +kubebuilder:rbac:groups="",namespace=fleet-default,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 // TODO: extend SetupWithManager with "Watches" and "WithEventFilter"
 func (r *SeedImageReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
Do not allow the seedimage-controller to operate on pods, services and configmaps outside of the fleet-default namespace.

This requires to introduce a Role and RoleBinding scoped on fleet-default along our ClusterRole and ClusterRoleBinding for the operator ServiceAccount.
Moved all the RBAC resources above under kustomize management and converted all in a rbac.yaml file under the chart template directory.

Fixes #457