### PR TITLE
Default to nmconnections configurator

### DIFF
--- a/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
+++ b/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
@@ -150,7 +150,7 @@ spec:
                       nmstate, or nmconnections formats)
                     x-kubernetes-preserve-unknown-fields: true
                   configurator:
-                    default: nmc
+                    default: nmconnections
                     description: Configurator
                     enum:
                     - nmc
@@ -956,7 +956,7 @@ spec:
                           nmstate, or nmconnections formats)
                         x-kubernetes-preserve-unknown-fields: true
                       configurator:
-                        default: nmc
+                        default: nmconnections
                         description: Configurator
                         enum:
                         - nmc

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -179,7 +179,7 @@ const (
 type NetworkTemplate struct {
 	// Configurator
 	// +kubebuilder:validation:Enum=nmc;nmstate;nmconnections
-	// +kubebuilder:default:=nmc
+	// +kubebuilder:default:=nmconnections
 	Configurator string `json:"configurator,omitempty" yaml:"configurator,omitempty"`
 	// IPAddresses contains a map of IPPools references
 	IPAddresses map[string]*corev1.TypedLocalObjectReference `json:"ipAddresses,omitempty" yaml:"ipAddresses,omitempty"`
@@ -203,7 +203,7 @@ type NetworkTemplate struct {
 type NetworkConfig struct {
 	// Configurator
 	// +kubebuilder:validation:Enum=nmc;nmstate;nmconnections
-	// +kubebuilder:default:=nmc
+	// +kubebuilder:default:=nmconnections
 	Configurator string `json:"configurator,omitempty" yaml:"configurator,omitempty"`
 	// IPAddresses contains a map of claimed IPAddresses
 	IPAddresses map[string]string `json:"ipAddresses,omitempty" yaml:"ipAddresses,omitempty"`

--- a/config/crd/bases/elemental.cattle.io_machineinventories.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineinventories.yaml
@@ -144,7 +144,7 @@ spec:
                       nmstate, or nmconnections formats)
                     x-kubernetes-preserve-unknown-fields: true
                   configurator:
-                    default: nmc
+                    default: nmconnections
                     description: Configurator
                     enum:
                     - nmc

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -190,7 +190,7 @@ spec:
                           nmstate, or nmconnections formats)
                         x-kubernetes-preserve-unknown-fields: true
                       configurator:
-                        default: nmc
+                        default: nmconnections
                         description: Configurator
                         enum:
                         - nmc


### PR DESCRIPTION
Due to the absence of `nmc` in the OS images, the default should be changed to `nmconnections` then, which will work out of the box.