### PR TITLE
Only reset network if a network configurator is used

### DIFF
--- a/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
+++ b/.obs/chartfile/elemental-operator-crds-helm/templates/crds.yaml
@@ -150,9 +150,10 @@ spec:
                       nmstate, or nmconnections formats)
                     x-kubernetes-preserve-unknown-fields: true
                   configurator:
-                    default: nmc
+                    default: none
                     description: Configurator
                     enum:
+                    - none
                     - nmc
                     - nmstate
                     - nmconnections
@@ -956,9 +957,10 @@ spec:
                           nmstate, or nmconnections formats)
                         x-kubernetes-preserve-unknown-fields: true
                       configurator:
-                        default: nmc
+                        default: none
                         description: Configurator
                         enum:
+                        - none
                         - nmc
                         - nmstate
                         - nmconnections

--- a/api/v1beta1/machineinventory_types.go
+++ b/api/v1beta1/machineinventory_types.go
@@ -51,6 +51,7 @@ type MachineInventorySpec struct {
 	// IPAddressPools is a list of IPAddressPool associated to this machine.
 	IPAddressPools map[string]*corev1.TypedLocalObjectReference `json:"ipAddressPools,omitempty"`
 	// NetworkConfig is the final NetworkConfig.
+	// +optional
 	Network NetworkConfig `json:"network,omitempty"`
 }
 

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -178,8 +178,8 @@ const (
 // NetworkTemplate contains a map of IPAddressPools and a schemaless network config template.
 type NetworkTemplate struct {
 	// Configurator
-	// +kubebuilder:validation:Enum=nmc;nmstate;nmconnections
-	// +kubebuilder:default:=nmc
+	// +kubebuilder:validation:Enum=none;nmc;nmstate;nmconnections
+	// +kubebuilder:default:=none
 	Configurator string `json:"configurator,omitempty" yaml:"configurator,omitempty"`
 	// IPAddresses contains a map of IPPools references
 	IPAddresses map[string]*corev1.TypedLocalObjectReference `json:"ipAddresses,omitempty" yaml:"ipAddresses,omitempty"`
@@ -202,8 +202,8 @@ type NetworkTemplate struct {
 // can do the substitution itself.
 type NetworkConfig struct {
 	// Configurator
-	// +kubebuilder:validation:Enum=nmc;nmstate;nmconnections
-	// +kubebuilder:default:=nmc
+	// +kubebuilder:validation:Enum=none;nmc;nmstate;nmconnections
+	// +kubebuilder:default:=none
 	Configurator string `json:"configurator,omitempty" yaml:"configurator,omitempty"`
 	// IPAddresses contains a map of claimed IPAddresses
 	IPAddresses map[string]string `json:"ipAddresses,omitempty" yaml:"ipAddresses,omitempty"`

--- a/config/crd/bases/elemental.cattle.io_machineinventories.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineinventories.yaml
@@ -144,9 +144,10 @@ spec:
                       nmstate, or nmconnections formats)
                     x-kubernetes-preserve-unknown-fields: true
                   configurator:
-                    default: nmc
+                    default: none
                     description: Configurator
                     enum:
+                    - none
                     - nmc
                     - nmstate
                     - nmconnections

--- a/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
+++ b/config/crd/bases/elemental.cattle.io_machineregistrations.yaml
@@ -190,9 +190,10 @@ spec:
                           nmstate, or nmconnections formats)
                         x-kubernetes-preserve-unknown-fields: true
                       configurator:
-                        default: nmc
+                        default: none
                         description: Configurator
                         enum:
+                        - none
                         - nmc
                         - nmstate
                         - nmconnections

--- a/controllers/machineinventory_controller.go
+++ b/controllers/machineinventory_controller.go
@@ -47,6 +47,7 @@ import (
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	systemagent "github.com/rancher/elemental-operator/internal/system-agent"
 	"github.com/rancher/elemental-operator/pkg/log"
+	"github.com/rancher/elemental-operator/pkg/network"
 	"github.com/rancher/elemental-operator/pkg/util"
 )
 
@@ -267,7 +268,7 @@ func (r *MachineInventoryReconciler) updatePlanSecretWithReset(ctx context.Conte
 	var resetPlan []byte
 	var err error
 
-	networkNeedsReset := len(mInventory.Spec.Network.Config) > 0
+	networkNeedsReset := mInventory.Spec.Network.Configurator != network.ConfiguratorNone
 
 	unmanaged, unmanagedFound := mInventory.Annotations[elementalv1.MachineInventoryOSUnmanagedAnnotation]
 	if unmanagedFound && unmanaged == "true" {

--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -33,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
+	systemagent "github.com/rancher/elemental-operator/internal/system-agent"
+	"github.com/rancher/elemental-operator/pkg/network"
 	"github.com/rancher/elemental-operator/pkg/test"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -226,6 +229,69 @@ var _ = Describe("createPlanSecret", func() {
 			Message: "plan successfully applied",
 		})
 		Expect(r.createPlanSecret(ctx, mInventory)).To(Succeed())
+	})
+
+	It("should not reset network if configurator none", func() {
+		inventoryWithNoneNetwork := &elementalv1.MachineInventory{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "machine-inventory-network-none",
+				Namespace: "default",
+			},
+			Spec: elementalv1.MachineInventorySpec{
+				Network: elementalv1.NetworkConfig{
+					Configurator: network.ConfiguratorNone,
+				},
+			},
+		}
+		Expect(r.Create(ctx, inventoryWithNoneNetwork)).Should(Succeed())
+		Expect(r.createPlanSecret(ctx, inventoryWithNoneNetwork)).To(Succeed())
+		Expect(r.Get(ctx, types.NamespacedName{Namespace: inventoryWithNoneNetwork.Namespace, Name: inventoryWithNoneNetwork.Name}, planSecret)).To(Succeed())
+		Expect(r.updatePlanSecretWithReset(ctx, inventoryWithNoneNetwork, planSecret)).Should(Succeed())
+		Expect(r.Get(ctx, types.NamespacedName{Namespace: inventoryWithNoneNetwork.Namespace, Name: inventoryWithNoneNetwork.Name}, planSecret)).To(Succeed())
+		planData, found := planSecret.Data["plan"]
+		Expect(found).To(BeTrue(), "Secret should contain reset plan data")
+
+		plan := &systemagent.Plan{}
+		Expect(json.Unmarshal(planData, plan)).Should(Succeed())
+		Expect(len(plan.OneTimeInstructions)).Should(Equal(2), "Should contain 2 reset instructions")
+		Expect(plan.OneTimeInstructions).ShouldNot(ContainElement(systemagent.OneTimeInstruction{
+			CommonInstruction: systemagent.CommonInstruction{
+				Name:    "restore first boot config",
+				Command: "elemental-register",
+				Args:    []string{"--debug", "--reset-network"},
+			}}))
+		Expect(test.CleanupAndWait(ctx, cl, inventoryWithNoneNetwork)).To(Succeed())
+	})
+
+	It("should reset network if configurator not none", func() {
+		inventoryWithNetwork := &elementalv1.MachineInventory{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "machine-inventory-network-nmc",
+				Namespace: "default",
+			},
+			Spec: elementalv1.MachineInventorySpec{
+				Network: elementalv1.NetworkConfig{
+					Configurator: network.ConfiguratorNmc,
+				},
+			},
+		}
+		Expect(r.Create(ctx, inventoryWithNetwork)).Should(Succeed())
+		Expect(r.createPlanSecret(ctx, inventoryWithNetwork)).To(Succeed())
+		Expect(r.Get(ctx, types.NamespacedName{Namespace: inventoryWithNetwork.Namespace, Name: inventoryWithNetwork.Name}, planSecret)).To(Succeed())
+		Expect(r.updatePlanSecretWithReset(ctx, inventoryWithNetwork, planSecret)).Should(Succeed())
+		Expect(r.Get(ctx, types.NamespacedName{Namespace: inventoryWithNetwork.Namespace, Name: inventoryWithNetwork.Name}, planSecret)).To(Succeed())
+		planData, found := planSecret.Data["plan"]
+		Expect(found).To(BeTrue(), "Secret should contain reset plan data")
+
+		plan := &systemagent.Plan{}
+		Expect(json.Unmarshal(planData, plan)).Should(Succeed())
+		Expect(plan.OneTimeInstructions).Should(ContainElement(systemagent.OneTimeInstruction{
+			CommonInstruction: systemagent.CommonInstruction{
+				Name:    "restore first boot config",
+				Command: "elemental-register",
+				Args:    []string{"--debug", "--reset-network"},
+			}}))
+		Expect(test.CleanupAndWait(ctx, cl, inventoryWithNetwork)).To(Succeed())
 	})
 })
 

--- a/controllers/machineinventory_controller_test.go
+++ b/controllers/machineinventory_controller_test.go
@@ -475,7 +475,7 @@ var _ = Describe("handle finalizer", func() {
 			Namespace: mInventory.Namespace,
 		}, mInventory)).To(Succeed())
 
-		wantChecksum, wantPlan, err := r.newResetPlan(ctx)
+		wantChecksum, wantPlan, err := r.newResetPlan(ctx, false)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Check Plan status

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -30,6 +30,13 @@ import (
 )
 
 const (
+	ConfiguratorNone          = "none"
+	ConfiguratorNmc           = "nmc"
+	ConfiguratorNmstate       = "nmstate"
+	ConfiguratorNmconnections = "nmconnections"
+)
+
+const (
 	// common
 	systemConnectionsDir = "/etc/NetworkManager/system-connections"
 	configApplicator     = "/oem/elemental-network.yaml"
@@ -70,13 +77,13 @@ func NewConfigurator(fs vfs.FS) Configurator {
 
 func (c *configurator) GetNetworkConfigApplicator(networkConfig elementalv1.NetworkConfig) (schema.YipConfig, error) {
 	switch networkConfig.Configurator {
-	case "nmc":
+	case ConfiguratorNmc:
 		nc := nmcConfigurator{fs: c.fs, runner: c.runner}
 		return nc.GetNetworkConfigApplicator(networkConfig)
-	case "nmstate":
+	case ConfiguratorNmstate:
 		nc := nmstateConfigurator{fs: c.fs, runner: c.runner}
 		return nc.GetNetworkConfigApplicator(networkConfig)
-	case "nmconnections":
+	case ConfiguratorNmconnections:
 		nc := networkManagerConfigurator{fs: c.fs, runner: c.runner}
 		return nc.GetNetworkConfigApplicator(networkConfig)
 	default:

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -77,6 +77,10 @@ func NewConfigurator(fs vfs.FS) Configurator {
 
 func (c *configurator) GetNetworkConfigApplicator(networkConfig elementalv1.NetworkConfig) (schema.YipConfig, error) {
 	switch networkConfig.Configurator {
+	case "":
+		return schema.YipConfig{}, nil
+	case ConfiguratorNone:
+		return schema.YipConfig{}, nil
 	case ConfiguratorNmc:
 		nc := nmcConfigurator{fs: c.fs, runner: c.runner}
 		return nc.GetNetworkConfigApplicator(networkConfig)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -122,8 +122,7 @@ func (c *configurator) ResetNetworkConfig() error {
 	}
 
 	// Delete all .nmconnection files. This will also delete any "static" connection that the user defined in the base image for example.
-	// Which means maybe that is not supported anymore, or if we want to support it we should make sure we only delete the ones created by elemental,
-	// for example prefixing all files with "elemental-" or just parsing the network config again at this stage to determine the file names.
+	// Note that ResetNetworkConfig() is only called when the network config is Elemental driven, hence we not expect any other custom connection defined.
 	log.Debug("Deleting all .nmconnection configs")
 	if err := c.runner.Run("find", systemConnectionsDir, "-name", "*.nmconnection", "-type", "f", "-delete"); err != nil {
 		return fmt.Errorf("deleting all %s/*.nmconnection: %w", systemConnectionsDir, err)

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -36,6 +36,7 @@ import (
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/hostinfo"
 	"github.com/rancher/elemental-operator/pkg/log"
+	"github.com/rancher/elemental-operator/pkg/network"
 	"github.com/rancher/elemental-operator/pkg/register"
 	"github.com/rancher/elemental-operator/pkg/templater"
 )
@@ -191,7 +192,7 @@ func (i *InventoryServer) writeMachineInventoryCloudConfig(conn *websocket.Conn,
 		return err
 	}
 
-	if len(netConf.Config) > 0 {
+	if netConf.Configurator != network.ConfiguratorNone {
 		netData, err := yaml.Marshal(netConf)
 		if err != nil {
 			log.Errorf("error marshalling network config: %v", err)

--- a/pkg/server/api_registration.go
+++ b/pkg/server/api_registration.go
@@ -192,7 +192,7 @@ func (i *InventoryServer) writeMachineInventoryCloudConfig(conn *websocket.Conn,
 		return err
 	}
 
-	if netConf.Configurator != network.ConfiguratorNone {
+	if netConf.Configurator != network.ConfiguratorNone && netConf.Configurator != "" {
 		netData, err := yaml.Marshal(netConf)
 		if err != nil {
 			log.Errorf("error marshalling network config: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -173,6 +173,9 @@ func initInventory(inventory *elementalv1.MachineInventory, registration *elemen
 		inventory.Spec.Network.Config = registration.Spec.Config.Network.Config
 		inventory.Spec.IPAddressPools = registration.Spec.Config.Network.IPAddresses
 	}
+	if registration.Spec.Config.Network.Configurator == "" {
+		inventory.Spec.Network.Configurator = network.ConfiguratorNone
+	}
 }
 
 func (i *InventoryServer) createMachineInventory(inventory *elementalv1.MachineInventory) (*elementalv1.MachineInventory, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,7 @@ import (
 
 	elementalv1 "github.com/rancher/elemental-operator/api/v1beta1"
 	"github.com/rancher/elemental-operator/pkg/log"
+	"github.com/rancher/elemental-operator/pkg/network"
 	"github.com/rancher/elemental-operator/pkg/plainauth"
 	"github.com/rancher/elemental-operator/pkg/register"
 	"github.com/rancher/elemental-operator/pkg/tpm"
@@ -167,7 +168,7 @@ func initInventory(inventory *elementalv1.MachineInventory, registration *elemen
 	}
 
 	// Forward network config from Registration
-	if len(registration.Spec.Config.Network.Config) > 0 {
+	if registration.Spec.Config.Network.Configurator != network.ConfiguratorNone {
 		inventory.Spec.Network.Configurator = registration.Spec.Config.Network.Configurator
 		inventory.Spec.Network.Config = registration.Spec.Config.Network.Config
 		inventory.Spec.IPAddressPools = registration.Spec.Config.Network.IPAddresses

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -167,9 +167,11 @@ func initInventory(inventory *elementalv1.MachineInventory, registration *elemen
 	}
 
 	// Forward network config from Registration
-	inventory.Spec.Network.Configurator = registration.Spec.Config.Network.Configurator
-	inventory.Spec.Network.Config = registration.Spec.Config.Network.Config
-	inventory.Spec.IPAddressPools = registration.Spec.Config.Network.IPAddresses
+	if len(registration.Spec.Config.Network.Config) > 0 {
+		inventory.Spec.Network.Configurator = registration.Spec.Config.Network.Configurator
+		inventory.Spec.Network.Config = registration.Spec.Config.Network.Config
+		inventory.Spec.IPAddressPools = registration.Spec.Config.Network.IPAddresses
+	}
 }
 
 func (i *InventoryServer) createMachineInventory(inventory *elementalv1.MachineInventory) (*elementalv1.MachineInventory, error) {


### PR DESCRIPTION
This PR prevents **always** clearing `/etc/NetworkManager/system-connections/*.nmconnections` during reset.

Instead, the Elemental managed network is reset only if an Elemental NetworkConfig is in use, so that users who are managing network in other ways will not be impacted.

To achieve this, the PR introduces a `none` Network configurator. This will also be used by default, so that it will be clear to the end user that the network is not managed by Elemental when this is the case. 
Any other configurator value is dependent on the schema used in the network config, therefore any other default than `none` should not be set. This is 100% up to the user choice.