### PR TITLE
Add created date to the ManagedOSVersion common metadata fields

### DIFF
--- a/api/v1beta1/managedosversion_types.go
+++ b/api/v1beta1/managedosversion_types.go
@@ -81,7 +81,10 @@ func (m *ManagedOSVersion) MetadataObject(v interface{}) error {
 
 // ImageCommons is the basic set of data every single image type has
 type ImageCommons struct {
+	// DisplayName is the human readable name for this image. It should include flavor, release version and type ('OS' or 'ISO').
 	DisplayName string `json:"displayName,omitempty"`
+	// Created displays the image creation date in Unix time format (ex. 1732636343).
+	Created int `json:"created,omitempty"`
 }
 
 // ISO is the basic set of data to refer to an specific ISO


### PR DESCRIPTION
Just to include the newly added `created` timestamp from: https://github.com/rancher/elemental-channels/pull/64

This is an enabler if we want to display the build date of any image to the end user on the UI.