### PR TITLE
golanci-lint: change output format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@ issues:
     - "zz_generated_*"
 output:
   formats: 
-    - format: github-actions
+    - format: colored-line-number
 linters:
   enable:
     - revive # replacement for golint


### PR DESCRIPTION
```
[...]
level=warning msg="[config_reader] The output format `github-actions` is
deprecated, please use `colored-line-number`"
[...]
```