### PR TITLE
[Airgap] extend yq support in the airgap script

### DIFF
--- a/scripts/elemental-airgap.sh
+++ b/scripts/elemental-airgap.sh
@@ -373,7 +373,10 @@ build_os_channel() {
 
     # defaultChannels has been introduced in 1.7 version
     # we can directly add the images in channel_list
-    get_chart_val channel_list "defaultChannels.*.image" "false"
+    get_chart_val channel_list "defaultChannels" "false"
+    if [ -n "$channel_list" ]; then
+        get_chart_val channel_list "defaultChannels[].image" "false"
+    fi
 
     if [[ -z "$channel_list" ]]; then
         # v1.4+ chart

--- a/scripts/elemental-airgap.sh
+++ b/scripts/elemental-airgap.sh
@@ -207,7 +207,7 @@ get_chart_val() {
     local local_fail=${3:-"true"}
     local local_condition="[[ \"\$$local_var\" == \"null\" ]]"
 
-    eval $local_var='$(helm show values $CHART_NAME_OPERATOR | eval yq eval '.${local_val}' | sed s/\"//g 2>&1)'
+    eval $local_var='$(helm show values $CHART_NAME_OPERATOR | eval yq '.${local_val}' | sed s/\"//g 2>&1)'
     if eval $local_condition; then
         if [[ "$local_fail" == "false" ]]; then
             log_debug "cannot find $local_val in $CHART_NAME_OPERATOR"


### PR DESCRIPTION
The airgap script used to work with the Mike Farah's yq.
Anyway, it was incompatible with the Andrey Kislyuk's yq version (which
is the main python3 version you would get via pip).

Make the airgap scriptcompatible with both.

Fixes #897 