### PR TITLE
[BACKPORT] seedimage: clean-up service on image download deadline (#719)

### DIFF
--- a/controllers/seedimage_controller.go
+++ b/controllers/seedimage_controller.go
@@ -868,18 +868,34 @@ func (r *SeedImageReconciler) createBuildImageService(ctx context.Context, seedI
 		return err
 	}
 
+	seedImageDeadlinePassed := false
+	if seedImgCondition := meta.FindStatusCondition(seedImg.Status.Conditions, elementalv1.SeedImageConditionReady); seedImgCondition != nil &&
+		seedImgCondition.Status == metav1.ConditionTrue &&
+		seedImgCondition.Reason == elementalv1.SeedImageBuildDeadline {
+		seedImageDeadlinePassed = true
+	}
+
 	if err == nil {
 		logger.V(5).Info("Service already there")
 
 		// ensure the service was created by us
 		for _, owner := range foundSvc.GetOwnerReferences() {
 			if owner.UID == seedImg.UID {
-				// nothing to do
+				if seedImageDeadlinePassed {
+					logger.V(5).Info("Seed image deadline passed, delete associated service", "service", foundSvc.Name)
+					if err := r.Delete(ctx, foundSvc); err != nil {
+						return fmt.Errorf("failed to delete service %s: %w", foundSvc.Name, err)
+					}
+				}
 				return nil
 			}
 		}
 
 		return fmt.Errorf("service already exists and was not created by this controller")
+	}
+
+	if seedImageDeadlinePassed {
+		return nil
 	}
 
 	logger.V(5).Info("Creating service")


### PR DESCRIPTION
* seedimage: clean-up service on image download deadline

We used to just clean-up the Pod carrying the built image when hitting the cleanupAfterMinutes deadline.
There is no need to leave the Service around, clean that up too.

Fixes #704

Signed-off-by: Francesco Giudici <francesco.giudici@suse.com>

* Update controllers/seedimage_controller.go

Co-authored-by: Fredrik Lönnegren <fredrik.lonnegren@gmail.com>
Signed-off-by: Francesco Giudici <francesco.giudici@gmail.com>

---------

Signed-off-by: Francesco Giudici <francesco.giudici@suse.com>
Signed-off-by: Francesco Giudici <francesco.giudici@gmail.com>
Co-authored-by: Fredrik Lönnegren <fredrik.lonnegren@gmail.com>
(cherry picked from commit 5f2b96c299d7bb2ce4a4b3f6180b9b304f10985b)