### PR TITLE
[1.6.x] Fix questions.yaml default tag

### DIFF
--- a/.obs/chartfile/operator/questions.yaml
+++ b/.obs/chartfile/operator/questions.yaml
@@ -14,7 +14,7 @@ questions:
     label: Elemental OS Channel Image
     group: "Elemental OS Channel"
   - variable: channel.tag
-    default: "6.0-baremetal"
+    default: "6.1-baremetal"
     description: "Specify Elemental OS channel image tag"
     type: string
     label: "Elemental OS Channel Tag"


### PR DESCRIPTION
Move the tag to 6.1-baremetal also on the questions.yaml file used by the Rancher Marketplace dialog.

align to #abbd2e75fcc01bc3caa78b4dbc2b9ebaa849d3a8