### PR TITLE
operator: update RBAC for upgrade plans

### DIFF
--- a/controllers/managedosimage_controller.go
+++ b/controllers/managedosimage_controller.go
@@ -272,7 +272,7 @@ func (r *ManagedOSImageReconciler) newFleetBundleResources(ctx context.Context, 
 					Resources: []string{"nodes"},
 				},
 				{
-					Verbs:     []string{"list"},
+					Verbs:     []string{"get", "list"},
 					APIGroups: []string{""},
 					Resources: []string{"pods"},
 				},

--- a/controllers/managedosimage_controller_test.go
+++ b/controllers/managedosimage_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("newFleetBundleResources", func() {
 
 		Expect(bundleResources).To(HaveLen(5))
 
-		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-28ceb391618a.yaml"))
+		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-d5689b3c1cd3.yaml"))
 		Expect(bundleResources[1].Name).To(Equal("ClusterRoleBinding--os-upgrader-test-name-cc7ce4275b54.yaml"))
 		Expect(bundleResources[2].Name).To(Equal("ServiceAccount-cattle-system-os-upgrader-test-name-08929531f5c0.yaml"))
 		Expect(bundleResources[3].Name).To(Equal("Secret-cattle-system-os-upgrader-test-name-52e9d8e041f4.yaml"))
@@ -166,7 +166,7 @@ var _ = Describe("newFleetBundleResources", func() {
 		bundleResources, err := r.newFleetBundleResources(ctx, managedOSImage)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-28ceb391618a.yaml"))
+		Expect(bundleResources[0].Name).To(Equal("ClusterRole--os-upgrader-test-name-d5689b3c1cd3.yaml"))
 		Expect(bundleResources[1].Name).To(Equal("ClusterRoleBinding--os-upgrader-test-name-cc7ce4275b54.yaml"))
 		Expect(bundleResources[2].Name).To(Equal("ServiceAccount-cattle-system-os-upgrader-test-name-08929531f5c0.yaml"))
 		Expect(bundleResources[3].Name).To(Equal("Secret-cattle-system-os-upgrader-test-name-52e9d8e041f4.yaml"))


### PR DESCRIPTION
Add "get" verb for Pod resources.

Fixes https://github.com/rancher/elemental/issues/1702