### PR TITLE
[v1.7.x] Dockerfile: bump golang container to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.22 AS build
+FROM registry.suse.com/bci/golang:1.24 AS build
 RUN zypper -n install -l openssl-devel
 WORKDIR /src
 COPY go.mod go.sum /src/

--- a/Dockerfile.seedimage
+++ b/Dockerfile.seedimage
@@ -1,5 +1,5 @@
 FROM ghcr.io/rancher/elemental-toolkit/elemental-cli:v1.1.0 AS toolkit
-FROM registry.suse.com/bci/golang:1.22 AS build
+FROM registry.suse.com/bci/golang:1.24 AS build
 WORKDIR /src
 COPY utils/httpfy/httpfy.go /src/
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Required since x/crypto lib now requires go version >= 1.23

Related to #dd41431b0b2792f0fca005adf3abc3cf471877c4