### PR TITLE
Label Templates: improve Random family processing

### DIFF
--- a/pkg/server/labeltmpl.go
+++ b/pkg/server/labeltmpl.go
@@ -93,7 +93,7 @@ func updateInventoryLabels(tmpl templater.Templater, inv *elementalv1.MachineInv
 				continue
 			}
 			log.Errorf("Templater failed decoding label %q: %s", v, err.Error())
-			return err
+			continue
 		}
 		decodedLabel = sanitizeLabel(decodedLabel)
 

--- a/pkg/templater/random.go
+++ b/pkg/templater/random.go
@@ -44,10 +44,12 @@ func IsRandomLabel(s string) bool {
 }
 
 func isRandomTemplate(tmplVal []string) bool {
+	if len(tmplVal) < 2 {
+		return false
+	}
 	if tmplVal[0] != tmplRandomKey {
 		return false
 	}
-
 	switch tmplVal[1] {
 	case tmplUUIDKey:
 	case tmplHexKey:


### PR DESCRIPTION
Fix checking malformed Random template vars (i.e., ${Random}) and avoid failing the whole registration when illegal Random template values are detected: in this case just log an error and skip that specific label only. 