### PR TITLE
Do not allow installing unpinned go modules

### DIFF
--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -16,6 +16,11 @@ if [ -z "${3}" ]; then
   exit 1
 fi
 
+if [ "${3}" = "latest" ]; then
+  echo "must provide a pinned version as third parameter, 'latest' is not valid"
+  exit 1
+fi
+
 if [ -z "${GOBIN}" ]; then
   echo "GOBIN is not set. Must set GOBIN to install the bin in a specified directory."
   exit 1


### PR DESCRIPTION
Just to ensure we are not tempted to use a `latest` version for some of the modules we install to setup the test environment. As of today all versions are pinned, this is is just a little extra sanity check.