### PR TITLE
fix: always store elemental.cattle.io/os.unmanaged regardless of labe…

### DIFF
--- a/pkg/server/api_registration_test.go
+++ b/pkg/server/api_registration_test.go
@@ -379,6 +379,13 @@ func TestMergeInventoryAnnotations(t *testing.T) {
 			false,
 			map[string]string{"key1": "val1", "custom.prefix/key2": "val2"},
 		},
+		{
+			[]byte(`{"os.unmanaged":"true"}`),
+			nil,
+			"",
+			false,
+			map[string]string{"elemental.cattle.io/os.unmanaged": "true"},
+		},
 	}
 
 	for _, test := range testCase {

--- a/pkg/server/labeltmpl.go
+++ b/pkg/server/labeltmpl.go
@@ -173,7 +173,15 @@ func mergeInventoryAnnotations(data []byte, mInventory *elementalv1.MachineInven
 		mInventory.Annotations = map[string]string{}
 	}
 	for key, val := range annotations {
-		mInventory.Annotations[prefix+sanitizeUserInput(key)] = sanitizeUserInput(val)
+		// os.unmanaged is an operator-internal signal that the reset controller
+		// uses to decide unmanaged vs toolkit reset plan. It must always be stored
+		// under the well-known elemental.cattle.io/os.unmanaged key, regardless of
+		// the configured labelPrefix.
+		targetKey := prefix + sanitizeUserInput(key)
+		if key == "os.unmanaged" {
+			targetKey = elementalv1.MachineInventoryOSUnmanagedAnnotation
+		}
+		mInventory.Annotations[targetKey] = sanitizeUserInput(val)
 	}
 	return nil
 }


### PR DESCRIPTION
…lPrefix

The os.unmanaged annotation is an operator-internal signal used by the reset controller. It must always be stored under the well-known elemental.cattle.io/os.unmanaged key, independent of MachineRegistration labelPrefix. Previously, labelPrefix: "-" would store it as plain "os.unmanaged", causing the reset controller to issue the wrong (toolkit) reset plan.

Fixes: rancher/elemental-operator#1023